### PR TITLE
ELOSP-442 Fix for the datetime picker on mobile

### DIFF
--- a/themes/elos/assets/javascripts/theme-application.js
+++ b/themes/elos/assets/javascripts/theme-application.js
@@ -10,6 +10,7 @@ $(document).on('turbolinks:load', function(){
   $(".datepicker").each(function() {
     var format = $(this).data('format');
     $(this).flatpickr({
+      disableMobile: true,
       enableTime: false,
       dateFormat: format,
       minDate: new Date(),


### PR DESCRIPTION
As said in https://flatpickr.js.org/mobile-support/, when it detects the user is on mobile, it tries to use the native datetime selection, which provides a UX that’s familiar to the user. But when the user tried to schedule a session for the same day, it wouldn't work. So, the native datetime inputs are now disabled. 
It was tested on the mobile versions of Chrome, Samsung Web and Safari browsers.