### PR TITLE
Add configs to scheduled meetings

### DIFF
--- a/app/controllers/scheduled_meetings_controller.rb
+++ b/app/controllers/scheduled_meetings_controller.rb
@@ -132,6 +132,11 @@ class ScheduledMeetingsController < ApplicationController
   end
 
   def external
+    # If the external link is disabled, users should get an error
+    # whether are they signed in or not
+    if @scheduled_meeting.disable_external_link
+      redirect_to errors_path(404)
+    end
     # allow signed in users to use this page, but autofill the inputs
     # and don't let users change them
     if @user.present?
@@ -167,7 +172,8 @@ class ScheduledMeetingsController < ApplicationController
 
   def scheduled_meeting_params(room)
     attrs = [
-      :name, :recording, :duration, :description, :welcome, :repeat
+      :name, :recording, :duration, :description, :welcome, :repeat,
+      :disable_external_link, :disable_private_chat, :disable_note
     ]
     attrs << [:wait_moderator] if room.allow_wait_moderator
     attrs << [:all_moderators] if room.allow_all_moderators

--- a/app/models/scheduled_meeting.rb
+++ b/app/models/scheduled_meeting.rb
@@ -104,6 +104,8 @@ class ScheduledMeeting < ApplicationRecord
       attendeePW: self.room.viewer,
       welcome: self.welcome,
       record: self.recording,
+      lockSettingsDisablePrivateChat: self.disable_private_chat,
+      lockSettingsDisableNote: self.disable_note
     }
 
     # set the duration + 1h if configured to do so in the consumer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,6 +137,11 @@ en:
         message:    "Unauthorized access"
         suggestion: "Try launching the app again by using the link or refreshing the browser."
         status_code: "401"
+      _404:
+        code:       "NotFound"
+        message:    "Not found"
+        suggestion: "The page you tried to access does not exist."
+        status_code: "404"
     bigbluebutton:
       invalid_request:
         code:       "BBBAPICallInvalid"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -106,6 +106,11 @@ pt:
         message:    "Acesso não autorizado"
         suggestion: "Tente iniciar a sala novamente no seu LMS ou tente atualizar esta página no seu navegador."
         status_code: "401"
+      _404:
+        code:       "NotFound"
+        message:    "Não encontrado"
+        suggestion: "A página que você tentou acessar não foi encontrada."
+        status_code: "404"
     bigbluebutton:
       invalid_request:
         code:       "BBBAPICallInvalid"

--- a/db/migrate/20200826174926_add_disable_flags_to_scheduled_meetings.rb
+++ b/db/migrate/20200826174926_add_disable_flags_to_scheduled_meetings.rb
@@ -1,0 +1,7 @@
+class AddDisableFlagsToScheduledMeetings < ActiveRecord::Migration[6.0]
+  def change
+    add_column(:scheduled_meetings, :disable_external_link, :boolean, default: false)
+    add_column(:scheduled_meetings, :disable_private_chat, :boolean, default: false)
+    add_column(:scheduled_meetings, :disable_note, :boolean, default: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_29_223644) do
+ActiveRecord::Schema.define(version: 2020_08_26_174926) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,9 @@ ActiveRecord::Schema.define(version: 2020_07_29_223644) do
     t.string "welcome"
     t.string "created_by_launch_nonce"
     t.string "repeat"
+    t.boolean "disable_external_link", default: false
+    t.boolean "disable_private_chat", default: false
+    t.boolean "disable_note", default: false
     t.index ["created_by_launch_nonce"], name: "index_scheduled_meetings_on_created_by_launch_nonce"
     t.index ["repeat"], name: "index_scheduled_meetings_on_repeat"
     t.index ["room_id"], name: "index_scheduled_meetings_on_room_id"

--- a/themes/elos/config/locales/en.yml
+++ b/themes/elos/config/locales/en.yml
@@ -19,6 +19,9 @@ en:
       scheduled_meeting:
         all_moderators: "Everyone joins as moderator"
         description: "Description (optional)"
+        disable_external_link: "Disable external link"
+        disable_private_chat: "Disable private chats"
+        disable_note: "Disable shared notes"
         duration: "Duration"
         name: "Session name"
         recording: "Allow the session to be recorded"

--- a/themes/elos/config/locales/pt.yml
+++ b/themes/elos/config/locales/pt.yml
@@ -19,6 +19,9 @@ pt:
       scheduled_meeting:
         all_moderators: "Todos entram como moderadores"
         description: "Descrição (opcional)"
+        disable_external_link: "Desabilitar link externo"
+        disable_private_chat: "Desabilitar chats privados"
+        disable_note: "Desabilitar notas compartilhadas"
         duration: "Duração"
         name: "Nome da sessão"
         recording: "Permitir que a sessão seja gravada"

--- a/themes/elos/views/scheduled_meetings/_form.html.erb
+++ b/themes/elos/views/scheduled_meetings/_form.html.erb
@@ -60,30 +60,57 @@
     </div>
   </div>
 
-  <div class="form-group">
-    <div class="form-check col-12">
-      <%= form.check_box :recording, class: "form-check-input" %>
-      <%= form.label :recording, class: "form-check-label" %>
+  <div class="form-row">
+    <div class="form-group col-12 col-md-6">
+      <div class="form-group">
+        <div class="form-check">
+          <%= form.check_box :recording, class: "form-check-input" %>
+          <%= form.label :recording, class: "form-check-label" %>
+        </div>
+      </div>
+
+      <% if @room.allow_wait_moderator %>
+        <div class="form-group">
+          <div class="form-check">
+            <%= form.check_box :wait_moderator, class: "form-check-input" %>
+            <%= form.label :wait_moderator, class: "form-check-label" %>
+          </div>
+        </div>
+      <% end %>
+
+      <% if @room.allow_all_moderators %>
+        <div class="form-group">
+          <div class="form-check">
+            <%= form.check_box :all_moderators, class: "form-check-input" %>
+            <%= form.label :all_moderators, class: "form-check-label" %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="form-group col-12 col-md-6">
+      <div class="form-group">
+        <div class="form-check">
+          <%= form.check_box :disable_external_link, class: "form-check-input" %>
+          <%= form.label :disable_external_link, class: "form-check-label" %>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <div class="form-check">
+          <%= form.check_box :disable_private_chat, class: "form-check-input" %>
+          <%= form.label :disable_private_chat, class: "form-check-label" %>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <div class="form-check">
+          <%= form.check_box :disable_note, class: "form-check-input" %>
+          <%= form.label :disable_note, class: "form-check-label" %>
+        </div>
+      </div>
     </div>
   </div>
-
-  <% if @room.allow_wait_moderator %>
-    <div class="form-group">
-      <div class="form-check col-12">
-        <%= form.check_box :wait_moderator, class: "form-check-input" %>
-        <%= form.label :wait_moderator, class: "form-check-label" %>
-      </div>
-    </div>
-  <% end %>
-
-  <% if @room.allow_all_moderators %>
-    <div class="form-group">
-      <div class="form-check col-12">
-        <%= form.check_box :all_moderators, class: "form-check-input" %>
-        <%= form.label :all_moderators, class: "form-check-label" %>
-      </div>
-    </div>
-  <% end %>
 
   <div class="form-actions">
     <%= link_to t('_all.cancel'), room_path(@room), class: "btn btn-light" %>

--- a/themes/elos/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/elos/views/shared/_scheduled_meeting_row.html.erb
@@ -34,16 +34,18 @@
           <i class="icon material-icons">more_vert</i>
         </a>
         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown-opts-<%= room.to_param %>">
-          <%=
-          link_to t('scheduled_meetings.external_link'), '#',
-           data: {
-             'clipboard-text': external_room_scheduled_meeting_url(room, meeting),
-             turbolinks: false,
-             'toast-id': '#external-link-copied-toast'
-           },
-           class: "dropdown-item copy-to-clipboard"
-          %>
-          <div class="dropdown-divider"></div>
+          <% unless meeting.disable_external_link %>
+            <%=
+            link_to t('scheduled_meetings.external_link'), '#',
+            data: {
+              'clipboard-text': external_room_scheduled_meeting_url(room, meeting),
+              turbolinks: false,
+              'toast-id': '#external-link-copied-toast'
+            },
+            class: "dropdown-item copy-to-clipboard"
+            %>
+            <div class="dropdown-divider"></div>
+          <% end %>
           <%=
           link_to t('scheduled_meetings.edit.action'),
            edit_room_scheduled_meeting_path(room, meeting),


### PR DESCRIPTION
New configs:
`disable_external_link`: disables the dropdown option to copy external link to copyboard and redirects users to error 404 if they access the meeting's external link.
`disable_private_chat`: config added to create_options. Disables private chats for non-moderators.
`disable_note`: config added to create_options. Non-moderators can only read shared notes.

- locales
- new migration
- modified views and permitted attributes for scheduled meetings
- modified 'external' action to render error 404 when the link is disabled
- Checkboxes in scheduled meeting `_form` partial are separated in 2 columns on tablets and desktop and 1 column on mobile devices.