### PR TITLE
Add BrightspaceCalendarEvent model

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -33,8 +33,7 @@ class SessionsController < ApplicationController
       when 'send_update_calendar_event'
         redirect_to send_update_calendar_event_room_scheduled_meeting_path(room_param, scheduled_meeting_param)
       when 'send_delete_calendar_event'
-        redirect_to send_delete_calendar_event_room_scheduled_meeting_path(room_param, scheduled_meeting_param,
-          { app_id: omniauth_params["app_id"], event_id: omniauth_params["event_id"] } )
+        redirect_to send_delete_calendar_event_room_scheduled_meeting_path(room_param, scheduled_meeting_param)
       end
     elsif provider == 'bbbltibroker'
       redirect_to(

--- a/app/models/brightspace_calendar_event.rb
+++ b/app/models/brightspace_calendar_event.rb
@@ -1,0 +1,3 @@
+class BrightspaceCalendarEvent < ApplicationRecord
+  belongs_to :scheduled_meetings
+end

--- a/app/models/brightspace_calendar_event.rb
+++ b/app/models/brightspace_calendar_event.rb
@@ -1,3 +1,7 @@
 class BrightspaceCalendarEvent < ApplicationRecord
-  belongs_to :scheduled_meetings
+  belongs_to :scheduled_meeting
+
+  validates :scheduled_meeting, presence: true, uniqueness: true
+  validates :room_id, presence: true
+  validates :event_id, presence: true, uniqueness: { scope: :room_id }
 end

--- a/app/models/scheduled_meeting.rb
+++ b/app/models/scheduled_meeting.rb
@@ -7,6 +7,7 @@ class ScheduledMeeting < ApplicationRecord
   }.stringify_keys.freeze
 
   belongs_to :room
+  has_one :brightspace_calendar_event
 
   validates :room, presence: true
   validates :name, presence: true

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -40,15 +40,23 @@ end
 # This will be called before every request_phase and callback_phase
 brightspace_setup_phase = lambda do |env|
   req = Rack::Request.new(env)
-  app_id = req.GET['app_id'] ||
-           env['rack.session']['omniauth.params']&.[]('app_id')
-  if app_id
-    app = AppLaunch.find app_id
-  else
-    scheduled_meeting_id = req.GET['id'] ||
-                         env['rack.session']['omniauth.params']&.[]('id')
-    scheduled_meeting = ScheduledMeeting.find scheduled_meeting_id
-    app = AppLaunch.find_by_nonce scheduled_meeting.created_by_launch_nonce
+  session = env['rack.session']
+
+  room_handler = req.GET&.[]('room_id') ||
+                 env['rack.session']&.[]('omniauth.params')&.[]('room_id')
+
+  # Fix this. This is the get_room_session in ApplicationController, but
+  # we can't access that method here
+  room = Room.find_by(handler: room_handler)
+  room_session = session&.[](ApplicationController::COOKIE_ROOMS_SCOPE) || {}
+  room_session_handler = if room.present? && room_session.key?(room.handler)
+    room_session[room.handler]
+  end
+
+  # Fix this. This is the find_app_launch in ApplicationController, but
+  # we can't access that method here
+  app = if room_session_handler.present?
+    AppLaunch.find_by(nonce: room_session_handler['launch'])
   end
 
   brightspace_oauth = app.brightspace_oauth

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -45,7 +45,7 @@ brightspace_setup_phase = lambda do |env|
   room_handler = req.GET&.[]('room_id') ||
                  env['rack.session']&.[]('omniauth.params')&.[]('room_id')
 
-  # Fix this. This is the get_room_session in ApplicationController, but
+  # FIXME. This is the get_room_session in ApplicationController, but
   # we can't access that method here
   room = Room.find_by(handler: room_handler)
   room_session = session&.[](ApplicationController::COOKIE_ROOMS_SCOPE) || {}
@@ -53,7 +53,7 @@ brightspace_setup_phase = lambda do |env|
     room_session[room.handler]
   end
 
-  # Fix this. This is the find_app_launch in ApplicationController, but
+  # FIXME. This is the find_app_launch in ApplicationController, but
   # we can't access that method here
   app = if room_session_handler.present?
     AppLaunch.find_by(nonce: room_session_handler['launch'])

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,9 @@ en:
       close_manually:  "This tab/window must be closed manually"
     scheduled_meeting:
       allmoderators:  "All moderators"
+      calendar:
+        description:
+          visit:      "Visit the scheduling page to access this class."
       created:        "The session was scheduled"
       destroy:
         confirmation: "Are you sure you want to remove this scheduled session?"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -43,6 +43,9 @@ pt:
       close_manually:  "Esta janela deve ser fechada manualmente"
     scheduled_meeting:
       allmoderators:  "Todos moderadores"
+      calendar:
+        description:
+          visit:      "Visite a página de agendamento para acessar esta aula."
       created:        "A sessão foi agendada"
       destroy:
         confirmation: "Você tem certeza que deseja remover este agendamento?"

--- a/db/migrate/20201028175923_create_brightspace_calendar_events.rb
+++ b/db/migrate/20201028175923_create_brightspace_calendar_events.rb
@@ -1,0 +1,16 @@
+class CreateBrightspaceCalendarEvents < ActiveRecord::Migration[6.0]
+  def change
+    create_table :brightspace_calendar_events do |t|
+      t.integer :event_id
+      t.references :scheduled_meeting, foreign_key: false
+      # room is purposefully redundant, it is used to validate the event after
+      # the scheduled meeting is removed.
+      t.references :room, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :brightspace_calendar_events, [:event_id, :scheduled_meeting_id, :room_id], unique: true, name: 'idx_brightspace_calendar_events_event_scheduled_meeting_room'
+  end
+end
+

--- a/db/migrate/20201028175923_create_brightspace_calendar_events.rb
+++ b/db/migrate/20201028175923_create_brightspace_calendar_events.rb
@@ -2,7 +2,7 @@ class CreateBrightspaceCalendarEvents < ActiveRecord::Migration[6.0]
   def change
     create_table :brightspace_calendar_events do |t|
       t.integer :event_id
-      t.references :scheduled_meeting, foreign_key: false
+      t.references :scheduled_meeting, foreign_key: false, unique: true
       # room is purposefully redundant, it is used to validate the event after
       # the scheduled meeting is removed.
       t.references :room, foreign_key: true
@@ -10,7 +10,6 @@ class CreateBrightspaceCalendarEvents < ActiveRecord::Migration[6.0]
       t.timestamps
     end
 
-    add_index :brightspace_calendar_events, [:event_id, :scheduled_meeting_id, :room_id], unique: true, name: 'idx_brightspace_calendar_events_event_scheduled_meeting_room'
+    add_index :brightspace_calendar_events, [:event_id, :room_id], unique: true
   end
 end
-

--- a/db/migrate/20201028181808_remove_brightspace_calendar_event_id_from_scheduled_meetings.rb
+++ b/db/migrate/20201028181808_remove_brightspace_calendar_event_id_from_scheduled_meetings.rb
@@ -1,0 +1,5 @@
+class RemoveBrightspaceCalendarEventIdFromScheduledMeetings < ActiveRecord::Migration[6.0]
+  def change
+    remove_column(:scheduled_meetings, :brightspace_calendar_event_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 2020_10_28_181808) do
     t.bigint "room_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["event_id", "scheduled_meeting_id", "room_id"], name: "idx_brightspace_calendar_events_event_scheduled_meeting_room", unique: true
+    t.index ["event_id", "room_id"], name: "index_brightspace_calendar_events_on_event_id_and_room_id", unique: true
     t.index ["room_id"], name: "index_brightspace_calendar_events_on_room_id"
     t.index ["scheduled_meeting_id"], name: "index_brightspace_calendar_events_on_scheduled_meeting_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_18_212845) do
+ActiveRecord::Schema.define(version: 2020_10_28_181808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,17 @@ ActiveRecord::Schema.define(version: 2020_10_18_212845) do
     t.string "room_handler"
     t.index ["nonce"], name: "index_app_launches_on_nonce"
     t.index ["room_handler"], name: "index_app_launches_on_room_handler"
+  end
+
+  create_table "brightspace_calendar_events", force: :cascade do |t|
+    t.integer "event_id"
+    t.bigint "scheduled_meeting_id"
+    t.bigint "room_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_id", "scheduled_meeting_id", "room_id"], name: "idx_brightspace_calendar_events_event_scheduled_meeting_room", unique: true
+    t.index ["room_id"], name: "index_brightspace_calendar_events_on_room_id"
+    t.index ["scheduled_meeting_id"], name: "index_brightspace_calendar_events_on_scheduled_meeting_id"
   end
 
   create_table "consumer_config_brightspace_oauths", force: :cascade do |t|
@@ -89,12 +100,12 @@ ActiveRecord::Schema.define(version: 2020_10_18_212845) do
     t.boolean "disable_external_link", default: false
     t.boolean "disable_private_chat", default: false
     t.boolean "disable_note", default: false
-    t.integer "brightspace_calendar_event_id"
     t.index ["created_by_launch_nonce"], name: "index_scheduled_meetings_on_created_by_launch_nonce"
     t.index ["repeat"], name: "index_scheduled_meetings_on_repeat"
     t.index ["room_id"], name: "index_scheduled_meetings_on_room_id"
   end
 
+  add_foreign_key "brightspace_calendar_events", "rooms"
   add_foreign_key "consumer_config_brightspace_oauths", "consumer_configs"
   add_foreign_key "consumer_config_servers", "consumer_configs"
 end

--- a/lib/brightspace_helper.rb
+++ b/lib/brightspace_helper.rb
@@ -34,6 +34,8 @@ module BrightspaceHelper
       RepeatUntilDate: repeat_until_date.utc
     }
 
+    description = add_visit_message_to(description)
+
     calendar_payload = {
       Title: title,
       Description: description,
@@ -78,5 +80,11 @@ module BrightspaceHelper
     else
       [1, 0]
     end
+  end
+
+  def add_visit_message_to(description)
+    t('default.scheduled_meeting.calendar.description.visit') +
+    "\n" +
+    description
   end
 end

--- a/scripts/ngrok_start.sh
+++ b/scripts/ngrok_start.sh
@@ -89,7 +89,7 @@ update_ngrok_addresses() {
     docker-compose -f $dc_file run app bundle exec rake db:environment:set RAILS_ENV=development
     docker-compose -f $dc_file run app bundle exec rake db:reset
     docker-compose -f $dc_file run app bundle exec rake "db:keys:add[$my_key:$my_secret]"
-    docker-compose -f $dc_file run app bundle exec rake "db:apps:add[tool,https://$address1/rooms/auth/bbbltibroker/callback,$my_internal_key,$my_internal_secret]"
+    docker-compose -f $dc_file run app bundle exec rake "db:apps:add[rooms,https://$address1/rooms/auth/bbbltibroker/callback,$my_internal_key,$my_internal_secret]"
   else
     echo "exiting"
     exit 1


### PR DESCRIPTION
The model is primarily used to separate the event from the scheduled
meeting, so we can access it even after the destruction of a
scheduled meeting.