### PR TITLE
ELOSP-578 Include link to the class in the calendar description

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -15,6 +15,7 @@ class RoomsController < ApplicationController
   before_action :find_room, except: %i[launch close]
   before_action :validate_room, except: %i[launch close]
   before_action :find_user
+  before_action :find_app_launch, only: %i[launch]
 
   before_action only: %i[show launch close] do
     authorize_user!(:show, @room)
@@ -46,7 +47,13 @@ class RoomsController < ApplicationController
 
   # GET /launch
   def launch
-    redirect_to(room_path(@room))
+    scheduled_meeting_id = @app_launch.custom_param('scheduled_meeting')
+    scheduled_meeting = ScheduledMeeting.find_by_id(scheduled_meeting_id)
+    if scheduled_meeting
+      redirect_to(external_room_scheduled_meeting_path(@room, scheduled_meeting))
+    else
+      redirect_to(room_path(@room))
+    end
   end
 
   # GET /rooms/close

--- a/app/models/app_launch.rb
+++ b/app/models/app_launch.rb
@@ -17,7 +17,7 @@ class AppLaunch < ApplicationRecord
       :allow_wait_moderator, :allow_all_moderators
     ].each do |attr|
       p[attr] = if has_custom_param?(attr.to_s)
-                  custom_param_value(attr.to_s)
+                  is_custom_param_true?(attr.to_s)
                 else
                   new_room.send(attr)
                 end
@@ -44,9 +44,12 @@ class AppLaunch < ApplicationRecord
       self.params['custom_params'].key?('custom_' + name)
   end
 
-  def custom_param_value(name)
-    self.has_custom_param?(name) &&
-      self.params['custom_params']['custom_' + name] == 'true'
+  def custom_param(name)
+    params['custom_params']&.[]('custom_' + name)
+  end
+
+  def custom_param_true?(name)
+    params['custom_params']&.[]('custom_' + name) == 'true'
   end
 
   # Note: this is how a handler of a room is defined after launch, changing this

--- a/app/models/brightspace_calendar_event.rb
+++ b/app/models/brightspace_calendar_event.rb
@@ -4,4 +4,5 @@ class BrightspaceCalendarEvent < ApplicationRecord
   validates :scheduled_meeting, presence: true, uniqueness: true
   validates :room_id, presence: true
   validates :event_id, presence: true, uniqueness: { scope: :room_id }
+  validates :link_id, uniqueness: { scope: :room_id }
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,7 @@ en:
       allmoderators:  "All moderators"
       calendar:
         description:
-          link:       "<a href=\"%{url}\">Click here to access this class.</a>"
+          link:       "Click here to access this class."
       created:        "The session was scheduled"
       destroy:
         confirmation: "Are you sure you want to remove this scheduled session?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,7 @@ en:
       allmoderators:  "All moderators"
       calendar:
         description:
-          visit:      "Visit the scheduling page to access this class."
+          link:       "<a href=\"%{url}\">Click here to access this class.</a>"
       created:        "The session was scheduled"
       destroy:
         confirmation: "Are you sure you want to remove this scheduled session?"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -48,7 +48,7 @@ pt:
       allmoderators:  "Todos moderadores"
       calendar:
         description:
-          visit:      "Visite a página de agendamento para acessar esta aula."
+          link:       "<a href=\"%{url}\">Clique aqui para acessar esta aula.</a>"
       created:        "A sessão foi agendada"
       destroy:
         confirmation: "Você tem certeza que deseja remover este agendamento?"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -48,7 +48,7 @@ pt:
       allmoderators:  "Todos moderadores"
       calendar:
         description:
-          link:       "<a href=\"%{url}\">Clique aqui para acessar esta aula.</a>"
+          link:       "Clique aqui para acessar esta aula."
       created:        "A sessão foi agendada"
       destroy:
         confirmation: "Você tem certeza que deseja remover este agendamento?"

--- a/db/migrate/20201124200408_add_link_id_to_brightspace_calendar_events.rb
+++ b/db/migrate/20201124200408_add_link_id_to_brightspace_calendar_events.rb
@@ -1,0 +1,7 @@
+class AddLinkIdToBrightspaceCalendarEvents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :brightspace_calendar_events, :link_id, :integer
+
+    add_index :brightspace_calendar_events, [:link_id, :room_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_28_181808) do
+ActiveRecord::Schema.define(version: 2020_11_24_200408) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,9 @@ ActiveRecord::Schema.define(version: 2020_10_28_181808) do
     t.bigint "room_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "link_id"
     t.index ["event_id", "room_id"], name: "index_brightspace_calendar_events_on_event_id_and_room_id", unique: true
+    t.index ["link_id", "room_id"], name: "index_brightspace_calendar_events_on_link_id_and_room_id", unique: true
     t.index ["room_id"], name: "index_brightspace_calendar_events_on_room_id"
     t.index ["scheduled_meeting_id"], name: "index_brightspace_calendar_events_on_scheduled_meeting_id"
   end

--- a/lib/brightspace_helper.rb
+++ b/lib/brightspace_helper.rb
@@ -1,40 +1,281 @@
+# frozen_string_literal: true
+
 module BrightspaceHelper
-  def build_calendar_url(app, event_id='')
+  def send_calendar_event(method, app, args)
+    case method
+    when :create
+      scheduled_meeting = args[:scheduled_meeting]
+
+      # create link
+      lti_link_data = send_create_link(app, scheduled_meeting)
+
+      # create quicklink
+      lti_quicklink_data = send_create_quicklink(app,
+                                                 scheduled_meeting,
+                                                 lti_link_data)
+
+      # create calendar entry
+      calendar_event_data = send_create_calendar_entry(app,
+                                                       scheduled_meeting,
+                                                       lti_quicklink_data)
+
+      { event_id: calendar_event_data['CalendarEventId'],
+        lti_link_id: lti_link_data['LtiLinkId'], }
+    when :update
+      scheduled_meeting = args[:scheduled_meeting]
+
+      # The API doesn't allow to delete the quicklink directly, the only way
+      # is by destroying the link that generated the quicklink.
+      # So, instead of updating the link, we destroy it, so it destroy the
+      # quicklink as well, and then we create it again.
+      send_delete_link(app, scheduled_meeting)
+
+      # recreate link
+      lti_link_data = send_create_link(app, scheduled_meeting)
+
+      # recreate quicklink
+      lti_quicklink_data = send_create_quicklink(app,
+                                                 scheduled_meeting,
+                                                 lti_link_data)
+
+      # update calendar entry
+      calendar_event_data = send_update_calendar_entry(app,
+                                                       scheduled_meeting,
+                                                       lti_quicklink_data)
+
+      { event_id: calendar_event_data['CalendarEventId'],
+        lti_link_id: lti_link_data['LtiLinkId'], }
+    when :delete
+      scheduled_meeting_id = args[:scheduled_meeting_id]
+      room = args[:room]
+
+      # delete calendar entry
+      send_delete_calendar_entry(app, scheduled_meeting_id, room)
+
+      # delete link (and quicklink)
+      send_delete_link(app, scheduled_meeting)
+    end
+  end
+
+  private
+
+  def send_create_link(app, scheduled_meeting)
+    create_link_event = build_event(:create_link,
+                                    app,
+                                    scheduled_meeting: scheduled_meeting)
+    send_event(:create, create_link_event)
+  end
+
+  def send_delete_link(app, scheduled_meeting_id)
+    delete_link_event = build_event(:delete_link,
+                                    app,
+                                    scheduled_meeting: scheduled_meeting_id)
+
+    send_event(:delete, delete_link_event)
+  end
+
+  def send_create_quicklink(app, scheduled_meeting, lti_link_data)
+    create_quicklink_event = build_event(:create_quicklink,
+                                         app,
+                                         scheduled_meeting: scheduled_meeting,
+                                         lti_link_data: lti_link_data)
+    send_event(:create, create_quicklink_event)
+  end
+
+  def send_create_calendar_entry(app, scheduled_meeting, lti_quicklink_data)
+    create_calendar_event = build_event(:create_calendar_entry,
+                                        app,
+                                        scheduled_meeting: scheduled_meeting,
+                                        lti_quicklink_data: lti_quicklink_data)
+    send_event(:create, create_calendar_event)
+  end
+
+  def send_update_calendar_entry(app, scheduled_meeting, lti_quicklink_data)
+    create_calendar_event = build_event(:create_calendar_entry,
+                                        app,
+                                        scheduled_meeting: scheduled_meeting,
+                                        lti_quicklink_data: lti_quicklink_data)
+    send_event(:update, create_calendar_event)
+  end
+
+  def send_delete_calendar_entry(app, scheduled_meeting_id, room)
+    delete_calendar_event = build_event(:delete_calendar_entry,
+                                        app,
+                                        scheduled_meeting_id: scheduled_meeting_id,
+                                        room: room)
+    send_event(:delete, delete_calendar_event)
+  end
+
+  def build_event(type, app, args)
+    omniauth_auth = session['omniauth_auth']['brightspace']
+    access_token = omniauth_auth['credentials']['token']
+    # refresh_token = omniauth_auth['credentials']['refresh_token']
+
+    headers = build_headers(access_token)
+
+    case type
+    when :create_link
+      scheduled_meeting = args[:scheduled_meeting]
+
+      url = build_link_url(:create, app)
+      payload = build_link_payload(scheduled_meeting)
+      event = [url, payload.to_json, headers]
+    when :update_link
+      scheduled_meeting = args[:scheduled_meeting]
+
+      event = BrightspaceCalendarEvent.find_by(scheduled_meeting_id: scheduled_meeting)
+      lti_link_id = event&.link_id
+
+      url = build_link_url(:update, app, lti_link_id)
+      payload = build_link_payload(scheduled_meeting)
+      event = [url, payload.to_json, headers]
+    when :delete_link
+      scheduled_meeting = args[:scheduled_meeting]
+
+      event = BrightspaceCalendarEvent.find_by(scheduled_meeting_id: scheduled_meeting)
+      lti_link_id = event&.link_id
+
+      url = build_link_url(:delete, app, lti_link_id)
+      event = [url, headers]
+    when :create_quicklink
+      lti_link_data = args[:lti_link_data]
+
+      url = build_quicklink_url(app, lti_link_data['LtiLinkId'])
+      payload = {}
+      event = [url, payload.to_json, headers]
+    when :create_calendar_entry, :update_calendar_entry
+      scheduled_meeting = args[:scheduled_meeting]
+      lti_quicklink_data = args[:lti_quicklink_data]
+      event_id = args[:scheduled_meeting].brightspace_calendar_event&.event_id || ''
+
+      url = build_calendar_url(app, event_id)
+      domain = app.brightspace_oauth.url
+      public_url = lti_quicklink_data['PublicUrl']
+                   .sub('{orgUnitId}', app.context_id)
+      quicklink = t('default.scheduled_meeting.calendar.description.link',
+                    url: "#{domain}#{public_url}")
+      payload = build_calendar_payload(scheduled_meeting, quicklink)
+      event = [url, payload.to_json, headers]
+    when :delete_calendar_entry
+      scheduled_meeting_id = args[:scheduled_meeting_id]
+      room = args[:room]
+
+      # Even though scheduled_meeting_id is unique, it's important to filter
+      # by room_id, so an authorized person can't delete an event from another
+      # room
+      event = BrightspaceCalendarEvent.find_by(room_id: room,
+                                               scheduled_meeting_id: scheduled_meeting_id)
+      event_id = event&.event_id
+      return nil unless event_id
+
+      url = build_calendar_url(app, event_id)
+      event = [url, headers]
+    end
+    event
+  end
+
+  def send_event(method, event)
+    action = case method
+             when :create
+               :post
+             when :update
+               :put
+             when :delete
+               :delete
+             end
+    response = RestClient.send(action, *event)
+    JSON.parse(response) if response.present?
+  rescue RestClient::ExceptionWithResponse => e
+    Rails.logger.error("Failed to send #{method} event: #{e.message}")
+  end
+
+  def build_link_url(method, app, lti_link_id = '')
     brightspace_oauth = app.brightspace_oauth
     domain = brightspace_oauth.url
-    version = "1.34"
+    version = '1.48'
+    case method
+    when :create
+      org_unit = app.context_id
+      "#{domain}/d2l/api/le/#{version}/lti/link/#{org_unit}"
+    when :delete, :update
+      "#{domain}/d2l/api/le/#{version}/lti/link/#{lti_link_id}"
+    end
+  end
+
+  def build_link_payload(scheduled_meeting)
+    lti_url = omniauth_bbbltibroker_url('/rooms/messages/blti')
+    payload = {
+      Title: "Elos Room #{scheduled_meeting.id}",
+      Url: lti_url,
+      Description: '',
+      Key: '',
+      PlainSecret: nil,
+      IsVisible: true,
+      SignMessage: true,
+      SignWithTc: true,
+      SendTcInfo: true,
+      SendContextInfo: true,
+      SendUserId: true,
+      SendUserName: true,
+      SendUserEmail: true,
+      SendLinkTitle: true,
+      SendLinkDescription: true,
+      SendD2LUserName: true,
+      SendD2LOrgDefinedId: true,
+      SendD2LOrgRoleId: true,
+      UseToolProviderSecuritySettings: true,
+      CustomParameters: [
+        { Name: 'custom_scheduled_meeting',
+          Value: scheduled_meeting.id, },
+      ],
+    }
+    payload
+  end
+
+  def build_quicklink_url(app, lti_link_id)
+    brightspace_oauth = app.brightspace_oauth
+    domain = brightspace_oauth.url
+    version = '1.48'
+    org_unit = app.context_id
+    "#{domain}/d2l/api/le/#{version}/lti/quicklink/#{org_unit}/#{lti_link_id}"
+  end
+
+  def build_calendar_url(app, event_id = '')
+    brightspace_oauth = app.brightspace_oauth
+    domain = brightspace_oauth.url
+    version = '1.48'
     org_unit = app.context_id
     "#{domain}/d2l/api/le/#{version}/#{org_unit}/calendar/event/#{event_id}"
   end
 
-  def build_calendar_payload(scheduled_meeting)
-    repeat_type, repeat_every = calendar_repeat_type scheduled_meeting.repeat
+  def build_calendar_payload(scheduled_meeting, quicklink)
+    repeat_type, repeat_every = calendar_repeat_type(scheduled_meeting.repeat)
     weak_day = scheduled_meeting.start_at.wday
 
     title = scheduled_meeting.name
-    description = scheduled_meeting.description
+    description = build_description(scheduled_meeting.description, quicklink)
     start_date_time = scheduled_meeting.start_at
-    end_date_time = (start_date_time+scheduled_meeting.duration)
+    end_date_time = (start_date_time + scheduled_meeting.duration)
 
     # 2 years seems to be the limit value that brightspace accepts
-    repeat_until_date = start_date_time.next_year 2
+    repeat_until_date = start_date_time.next_year(2)
 
-    recurrence_info = repeat_type == 1 ? nil : {
-      RepeatType: repeat_type,
-      RepeatEvery: repeat_every,
-      RepeatOnInfo: {
-        Monday:    weak_day == 1,
-        Tuesday:   weak_day == 2,
-        Wednesday: weak_day == 3,
-        Thursday:  weak_day == 4,
-        Friday:    weak_day == 5,
-        Saturday:  weak_day == 6,
-        Sunday:    weak_day == 7
-      },
-      RepeatUntilDate: repeat_until_date.utc
-    }
-
-    description = add_visit_message_to(description)
+    recurrence_info = if repeat_type > 1
+                        {
+                          RepeatType: repeat_type,
+                          RepeatEvery: repeat_every,
+                          RepeatOnInfo: {
+                            Monday: weak_day == 1,
+                            Tuesday: weak_day == 2,
+                            Wednesday: weak_day == 3,
+                            Thursday: weak_day == 4,
+                            Friday: weak_day == 5,
+                            Saturday: weak_day == 6,
+                            Sunday: weak_day == 7,
+                          },
+                          RepeatUntilDate: repeat_until_date.utc,
+                        }
+                      end
 
     calendar_payload = {
       Title: title,
@@ -46,45 +287,42 @@ module BrightspaceHelper
       GroupId: nil,
       RecurrenceInfo: recurrence_info,
       LocationId: nil,
-      LocationName: "",
+      LocationName: '',
       AssociatedEntity: nil,
       VisibilityRestrictions: {
         Type: 1,
         Range: nil,
         HiddenRangeUnitType: nil,
         StartDate: nil,
-        EndDate: nil
-      }
+        EndDate: nil,
+      },
     }
 
     calendar_payload
   end
 
-  def build_calendar_headers(access_token)
-    {
-      Authorization: "Bearer #{access_token}",
-      content_type: :json,
-      accept: :json
-    }
+  def build_description(description, quicklink)
+    description = "#{quicklink}\n#{description}"
+    # Split each line into paragraphs
+    description.split("\n").map { |line| "<p>#{line}</p>" }.join
   end
-
-  private
 
   def calendar_repeat_type(repeat)
     return [1, 0] unless repeat
+
     case repeat
-    when "weekly"
+    when 'weekly'
       [3, 1]
-    when "every_two_weeks"
+    when 'every_two_weeks'
       [3, 2]
     else
       [1, 0]
     end
   end
 
-  def add_visit_message_to(description)
-    t('default.scheduled_meeting.calendar.description.visit') +
-    "\n" +
-    description
+  def build_headers(access_token)
+    { Authorization: "Bearer #{access_token}",
+      content_type: :json,
+      accept: :json, }
   end
 end

--- a/lib/brightspace_helper.rb
+++ b/lib/brightspace_helper.rb
@@ -152,9 +152,8 @@ module BrightspaceHelper
       domain = app.brightspace_oauth.url
       public_url = lti_quicklink_data['PublicUrl']
                    .sub('{orgUnitId}', app.context_id)
-      quicklink = t('default.scheduled_meeting.calendar.description.link',
-                    url: "#{domain}#{public_url}")
-      payload = build_calendar_payload(scheduled_meeting, quicklink)
+      quicklink_url = "#{domain}#{public_url}"
+      payload = build_calendar_payload(scheduled_meeting, quicklink_url)
       event = [url, payload.to_json, headers]
     when :delete_calendar_entry
       scheduled_meeting_id = args[:scheduled_meeting_id]
@@ -248,12 +247,12 @@ module BrightspaceHelper
     "#{domain}/d2l/api/le/#{version}/#{org_unit}/calendar/event/#{event_id}"
   end
 
-  def build_calendar_payload(scheduled_meeting, quicklink)
+  def build_calendar_payload(scheduled_meeting, quicklink_url)
     repeat_type, repeat_every = calendar_repeat_type(scheduled_meeting.repeat)
     weak_day = scheduled_meeting.start_at.wday
 
     title = scheduled_meeting.name
-    description = build_description(scheduled_meeting.description, quicklink)
+    description = build_description(scheduled_meeting.description, quicklink_url)
     start_date_time = scheduled_meeting.start_at
     end_date_time = (start_date_time + scheduled_meeting.duration)
 
@@ -301,8 +300,11 @@ module BrightspaceHelper
     calendar_payload
   end
 
-  def build_description(description, quicklink)
-    description = "#{quicklink}\n#{description}"
+  def build_description(description, quicklink_url)
+    link_text = t('default.scheduled_meeting.calendar.description.link')
+    link = "<a href=\"#{quicklink_url}\" target=\"_blank\">#{link_text}</a>"
+    description = "#{link}\n#{description}"
+
     # Split each line into paragraphs
     description.split("\n").map { |line| "<p>#{line}</p>" }.join
   end


### PR DESCRIPTION
- Added link_id to the BrightspaceCalendarEvent model. It's necessary to remove the link later.
- The quicklink is now inserted in the calendar description. The quicklink redirect the user to external_room_scheduled_meeting_path
- Moved some code from BrightspaceController to BrightspaceHelper module and made a lot of changes to improve the flow of the requests to the API.