### PR TITLE
LTI-42 Fix ended recurring meetings

### DIFF
--- a/app/controllers/scheduled_meetings_controller.rb
+++ b/app/controllers/scheduled_meetings_controller.rb
@@ -161,6 +161,9 @@ class ScheduledMeetingsController < ApplicationController
       @first_name = @user.first_name
       @last_name = @user.last_name
     end
+
+    @scheduled_meeting.update_to_next_recurring_date
+
     @ended = !@scheduled_meeting.active? && !mod_in_room?(@scheduled_meeting)
 
     @disclaimer = ConsumerConfig

--- a/app/models/scheduled_meeting.rb
+++ b/app/models/scheduled_meeting.rb
@@ -94,6 +94,10 @@ class ScheduledMeeting < ApplicationRecord
     start_at + duration.seconds >= DateTime.now.utc - tolerance
   end
 
+  def recurring?
+    repeat.present?
+  end
+
   def meeting_id
     "#{room.meeting_id}-#{self.id}"
   end
@@ -199,7 +203,7 @@ class ScheduledMeeting < ApplicationRecord
   # Update this scheduled meeting to the date it should be in its next iteration.
   # If this is not a recurring meeting or if this meeting is still active won't do anything.
   def update_to_next_recurring_date
-    return if self.repeat.blank? || self.active?
+    return if !self.recurring? || self.active?
 
     self.start_at += ScheduledMeeting::REPEAT_OPTIONS[self.repeat] while !self.active?
     self.save


### PR DESCRIPTION
Call `update_to_next_recurring_date` on `ScheduledMeeting::external`.