### PR TITLE
LTI-53 Make ScheduledMeeting URL ids random

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,5 +109,8 @@ gem 'browser-timezone-rails', git: 'https://github.com/mconf/browser-timezone-ra
 # Pagination
 gem 'kaminari'
 
+# Friendly URL
+gem 'friendly_id', '~> 5.4.0'
+
 # Other
 gem 'browser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
     ffi (1.13.0)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
+    friendly_id (5.4.2)
+      activerecord (>= 4.0.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.2.1)
@@ -408,6 +410,7 @@ DEPENDENCIES
   coffee-rails (~> 5.0)
   dotenv-rails
   font-awesome-rails
+  friendly_id (~> 5.4.0)
   jbuilder (~> 2.5)
   jquery-fileupload-rails
   jquery-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -130,6 +130,15 @@ class ApplicationController < ActionController::Base
 
   def find_scheduled_meeting
     @scheduled_meeting = @room.scheduled_meetings.from_param(params[:id])
+    # Fail if scheduled meeting was not found
+    return if @scheduled_meeting.blank?
+
+    # Succeed if scheduled_meeting was found with friendly_id
+    return @scheduled_meeting if @scheduled_meeting.friendly_id == params[:id]
+
+    # Redirect if scheduled_meeting was found with regular id
+    redirect_to(url_for(id: @scheduled_meeting.friendly_id),
+                status: :moved_permanently)
   end
 
   def validate_scheduled_meeting

--- a/app/models/concerns/friendlyable.rb
+++ b/app/models/concerns/friendlyable.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Friendlyable
+  extend ActiveSupport::Concern
+
+  ALPHANUM = [*'a'..'z', *'A'..'Z', *'0'..'9'].freeze
+
+  included do
+    extend ::FriendlyId
+    before_create :set_hash_id
+    friendly_id :hash_id
+  end
+
+  def set_hash_id
+    hash_id = nil
+    id_length = 5
+    loop do
+      hash_id = SecureRandom.urlsafe_base64(id_length)
+      hash_id = replace_prohibited_chars(hash_id)
+      break unless self.class.name.constantize.exists?(hash_id: hash_id)
+    end
+    self.hash_id = hash_id
+  end
+
+  private
+
+  # Replace '-' and '_' from str with random alphanumeric chars
+  def replace_prohibited_chars(str)
+    str.gsub(/-|_/) { |_| ALPHANUM.sample }
+  end
+end

--- a/app/models/concerns/friendlyable.rb
+++ b/app/models/concerns/friendlyable.rb
@@ -11,9 +11,10 @@ module Friendlyable
     friendly_id :hash_id
   end
 
+  # Create a random unique hash_id consisting of 9 alphanum chars
   def set_hash_id
     hash_id = nil
-    id_length = 5
+    id_length = 9
     loop do
       hash_id = SecureRandom.urlsafe_base64(id_length)
       hash_id = replace_prohibited_chars(hash_id)

--- a/app/models/scheduled_meeting.rb
+++ b/app/models/scheduled_meeting.rb
@@ -40,7 +40,12 @@ class ScheduledMeeting < ApplicationRecord
   }
 
   def self.from_param(param)
-    friendly.find_by(hash_id: param)
+    # This will accept both id an hash_id
+    # If we want to accept only hash_id change it to:
+    #   friendly.find_by(hash_id: param)
+    friendly.find(param)
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 
   def self.durations_for_select(locale)

--- a/app/models/scheduled_meeting.rb
+++ b/app/models/scheduled_meeting.rb
@@ -1,4 +1,6 @@
 class ScheduledMeeting < ApplicationRecord
+  include Friendlyable
+
   paginates_per 10
 
   REPEAT_OPTIONS = {
@@ -38,11 +40,7 @@ class ScheduledMeeting < ApplicationRecord
   }
 
   def self.from_param(param)
-    find_by(id: param)
-  end
-
-  def to_param
-    self.id.to_s
+    friendly.find_by(hash_id: param)
   end
 
   def self.durations_for_select(locale)

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,107 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+    
+  # This adds an option to treat reserved words as conflicts rather than exceptions.
+  # When there is no good candidate, a UUID will be appended, matching the existing
+  # conflict behavior.
+
+  # config.treat_reserved_as_conflict = true
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # By default, slug has no size limit, but you can change it if you wish.
+  #
+  # config.slug_limit = 255
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  # Note that you must use the :slugged addon **prior** to the line which
+  # configures the sequence separator, or else FriendlyId will raise an undefined
+  # method error.
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  # Note: Use(include) Slugged module in the config if using the anonymous module.
+  # If you have `friendly_id :name, use: slugged` in the model, Slugged module
+  # is included after the anonymous module defined in the initializer, so it
+  # overrides the `should_generate_new_friendly_id?` method from the anonymous module.
+  #
+  # config.use :slugged
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20210504222633_add_hash_id_to_scheduled_meetings.rb
+++ b/db/migrate/20210504222633_add_hash_id_to_scheduled_meetings.rb
@@ -1,0 +1,6 @@
+class AddHashIdToScheduledMeetings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :scheduled_meetings, :hash_id, :string
+    add_index :scheduled_meetings, :hash_id, unique: true
+  end
+end

--- a/db/migrate/20210504222633_add_hash_id_to_scheduled_meetings.rb
+++ b/db/migrate/20210504222633_add_hash_id_to_scheduled_meetings.rb
@@ -1,6 +1,16 @@
 class AddHashIdToScheduledMeetings < ActiveRecord::Migration[6.0]
-  def change
+  def up
     add_column :scheduled_meetings, :hash_id, :string
     add_index :scheduled_meetings, :hash_id, unique: true
+
+    ScheduledMeeting.find_each do |s|
+      s.set_hash_id
+      s.save
+    end
+  end
+
+  def down
+    remove_column :scheduled_meetings, :hash_id, :string
+    remove_index :scheduled_meetings, :hash_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_24_200408) do
+ActiveRecord::Schema.define(version: 2021_05_04_222633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -102,7 +102,9 @@ ActiveRecord::Schema.define(version: 2020_11_24_200408) do
     t.boolean "disable_external_link", default: false
     t.boolean "disable_private_chat", default: false
     t.boolean "disable_note", default: false
+    t.string "hash_id"
     t.index ["created_by_launch_nonce"], name: "index_scheduled_meetings_on_created_by_launch_nonce"
+    t.index ["hash_id"], name: "index_scheduled_meetings_on_hash_id", unique: true
     t.index ["repeat"], name: "index_scheduled_meetings_on_repeat"
     t.index ["room_id"], name: "index_scheduled_meetings_on_room_id"
   end


### PR DESCRIPTION
A hash_id field was added to store the random id.
The friendly_id gem is used, it's not really necessary but might be
handy in the future.
The Friendlyable concern is responsible for creating a random and unique
hash_id.