### PR TITLE
LTI-52 Added permission download recording

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,6 +34,10 @@ module ApplicationHelper
     Abilities.can?(user, :edit, resource)
   end
 
+  def can_download_recording?(user, resource)
+    Abilities.can?(user, :download_presentation_video, resource)
+  end
+
   def theme_defined?
     !Rails.configuration.theme.blank?
   end

--- a/app/models/abilities.rb
+++ b/app/models/abilities.rb
@@ -8,12 +8,24 @@ class Abilities
     when :show
       true
     when :edit
-      user.present? && (user.admin? || user.moderator?(self.moderator_roles))
+      user.present? && self.full_permission?(user)
     when :admin
       user.present? && user.admin?
+    when :download_presentation_video
+      config = ConsumerConfig.select(:download_presentation_video)
+        .find_by(key: resource[:consumer_key])
+      if config[:download_presentation_video]
+        user.present?
+      else
+        user.present? && self.full_permission?(user)
+      end
     else
       false
     end
+  end
+
+  def self.full_permission?(user)
+    user.admin? || user.moderator?(self.moderator_roles)
   end
 
   def self.moderator_roles

--- a/app/models/abilities.rb
+++ b/app/models/abilities.rb
@@ -13,7 +13,7 @@ class Abilities
       user.present? && user.admin?
     when :download_presentation_video
       config = ConsumerConfig.select(:download_presentation_video)
-        .find_by(key: resource[:consumer_key])
+                                    .find_by(key: resource[:consumer_key])
       if config[:download_presentation_video]
         user.present?
       else

--- a/db/migrate/20210525175309_add_download_presentation_video_to_consumer_config.rb
+++ b/db/migrate/20210525175309_add_download_presentation_video_to_consumer_config.rb
@@ -1,0 +1,5 @@
+class AddDownloadPresentationVideoToConsumerConfig < ActiveRecord::Migration[6.0]
+  def change
+    add_column(:consumer_configs, :download_presentation_video, :boolean, default: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_04_222633) do
+ActiveRecord::Schema.define(version: 2021_05_25_175309) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2021_05_04_222633) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "set_duration", default: false
+    t.boolean "download_presentation_video", default: true
     t.index ["key"], name: "index_consumer_configs_on_key", unique: true
   end
 

--- a/themes/elos/views/shared/_recording_row.html.erb
+++ b/themes/elos/views/shared/_recording_row.html.erb
@@ -36,12 +36,12 @@
 
         <% if recording[:published] %>
           <% url = playback_url(room, recording[:recordID],
-            recording[:playbacks].find { |p| p[:type] == 'presentation' })
+                                recording[:playbacks].find { |p| p[:type] == 'presentation' })
           %>
           <%= link_to t("recordings.playbacks.presentation"), url, class: "dropdown-item", target: "_blank" %>
           <% if can_download_recording?(user, room)%>
             <% url = playback_url(room, recording[:recordID],
-              recording[:playbacks].find { |p| p[:type] == 'presentation_video' })
+                                  recording[:playbacks].find { |p| p[:type] == 'presentation_video' })
             %>
             <%= link_to t("recordings.playbacks.presentation_video"), url, class: "dropdown-item", target: "_blank" %>
           <% end %>

--- a/themes/elos/views/shared/_recording_row.html.erb
+++ b/themes/elos/views/shared/_recording_row.html.erb
@@ -35,14 +35,21 @@
       <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown-opts-<%= recording[:recordID] %>">
 
         <% if recording[:published] %>
-          <% recording[:playbacks].each do |p| %>
-            <% url = playback_url(room, recording[:recordID], p) %>
-            <%= link_to t("recordings.playbacks.#{p[:type]}"), url, class: "dropdown-item", target: "_blank" %>
+          <% url = playback_url(room, recording[:recordID],
+            recording[:playbacks].find { |p| p[:type] == 'presentation' })
+          %>
+          <%= link_to t("recordings.playbacks.presentation"), url, class: "dropdown-item", target: "_blank" %>
+          <% if can_download_recording?(user, room)%>
+            <% url = playback_url(room, recording[:recordID],
+              recording[:playbacks].find { |p| p[:type] == 'presentation_video' })
+            %>
+            <%= link_to t("recordings.playbacks.presentation_video"), url, class: "dropdown-item", target: "_blank" %>
           <% end %>
+
+          <div class="dropdown-divider"></div>
 
           <% playback = recording[:playbacks].find { |p| p[:type] == 'presentation' } %>
           <% if playback.present? %>
-            <div class="dropdown-divider"></div>
             <%=
             link_to t('recordings.playback_link'), '#',
              data: {


### PR DESCRIPTION
With this configuration option in the consumer config, you can define whether to allow the download of the recording or not.
By default all users can download, download_presentation_video is true. When not true only users within the defined group of roles have access to the download link
