### PR TITLE
Fixed release 0.5.x elos

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,7 +32,9 @@ Rails.application.configure do
   end
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
+  # config.assets.js_compressor = :uglifier
+
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -19,6 +19,7 @@ theme = Rails.application.config.theme
 
 unless theme.blank?
   # the entrypoint for the styles of the theme
+  Rails.application.config.assets.precompile << /\.(?:svg)\z/
   Rails.application.config.assets.precompile += %w( theme-application.css theme-application.js schedule.js )
   Rails.application.config.assets.precompile += [
     Proc.new { |path, fn| fn =~ /themes\/#{theme}/ && !%w(.js .css).include?(File.extname(path)) }

--- a/themes/elos/assets/stylesheets/_definitions.scss
+++ b/themes/elos/assets/stylesheets/_definitions.scss
@@ -158,7 +158,7 @@ $line-height-lg: map-get($vars, '--line-height') !default;
   background-repeat: no-repeat;
   background-position-x: calc(100% - .75em);
   background-position-y: center;
-  background-image: asset-data-url("icon_expand_more.svg")
+  background-image: url(image-path('icon_expand_more.svg'))
 }
 
 select.form-control {


### PR DESCRIPTION
Enabled ES6 syntax in js_compressor => https://github.com/lautis/uglifier/issues/127
Fixed path to get image in definition.scss file
Added path's to precompile images
