### PR TITLE
LTI-71 Fix error on meeting destruction

### DIFF
--- a/app/controllers/brightspace_controller.rb
+++ b/app/controllers/brightspace_controller.rb
@@ -27,7 +27,7 @@ class BrightspaceController < ApplicationController
 
       local_params = { event_id: event_data[:event_id],
                        link_id: event_data[:lti_link_id],
-                       scheduled_meeting_id: @scheduled_meeting.id,
+                       scheduled_meeting_hash_id: @scheduled_meeting.hash_id,
                        room_id: @scheduled_meeting.room_id, }
       BrightspaceCalendarEvent.find_or_create_by(local_params)
     rescue BrightspaceHelper::SendCalendarEventError => e
@@ -49,7 +49,7 @@ class BrightspaceController < ApplicationController
                        link_id: event_data[:lti_link_id],
                        room_id: @scheduled_meeting.room_id, }
       BrightspaceCalendarEvent
-        .find_or_create_by(scheduled_meeting_id: @scheduled_meeting.id)
+        .find_or_create_by(scheduled_meeting_hash_id: @scheduled_meeting.hash_id)
         &.update(local_params)
     rescue BrightspaceHelper::SendCalendarEventError => e
       Rails.logger.warn("Failed to receive send_update_calendar_event data, " \
@@ -64,10 +64,10 @@ class BrightspaceController < ApplicationController
     begin
       send_calendar_event(:delete,
                           @app_launch,
-                          scheduled_meeting_id: permitted_params[:id],
+                          scheduled_meeting_hash_id: permitted_params[:id],
                           room: @room)
       BrightspaceCalendarEvent
-        .find_by(scheduled_meeting_id: permitted_params[:id], room_id: @room.id)
+        .find_by(scheduled_meeting_hash_id: permitted_params[:id], room_id: @room.id)
         &.delete
     rescue BrightspaceHelper::SendCalendarEventError => e
       Rails.logger.warn("Failed to send delete calendar event. " \

--- a/app/models/brightspace_calendar_event.rb
+++ b/app/models/brightspace_calendar_event.rb
@@ -1,7 +1,10 @@
 class BrightspaceCalendarEvent < ApplicationRecord
-  belongs_to :scheduled_meeting
+  belongs_to :scheduled_meeting,
+             primary_key: :hash_id,
+             foreign_key: :scheduled_meeting_hash_id,
+             inverse_of: :brightspace_calendar_event
 
-  validates :scheduled_meeting, presence: true, uniqueness: true
+  validates :scheduled_meeting_hash_id, presence: true, uniqueness: true
   validates :room_id, presence: true
   validates :event_id, presence: true, uniqueness: { scope: :room_id }
   validates :link_id, uniqueness: { scope: :room_id }

--- a/app/models/scheduled_meeting.rb
+++ b/app/models/scheduled_meeting.rb
@@ -9,7 +9,10 @@ class ScheduledMeeting < ApplicationRecord
   }.stringify_keys.freeze
 
   belongs_to :room
-  has_one :brightspace_calendar_event
+  has_one :brightspace_calendar_event,
+          primary_key: :hash_id,
+          foreign_key: :scheduled_meeting_hash_id,
+          inverse_of: :scheduled_meeting
 
   validates :room, presence: true
   validates :name, presence: true

--- a/db/migrate/20210706140832_change_brightspace_calendar_event_foreign_key.rb
+++ b/db/migrate/20210706140832_change_brightspace_calendar_event_foreign_key.rb
@@ -1,0 +1,35 @@
+class ChangeBrightspaceCalendarEventForeignKey < ActiveRecord::Migration[6.0]
+  def up
+    change_column :brightspace_calendar_events, :scheduled_meeting_id, :string
+    rename_column :brightspace_calendar_events,
+                  :scheduled_meeting_id,
+                  :scheduled_meeting_hash_id
+
+    query = <<-SQL
+      UPDATE brightspace_calendar_events
+      SET scheduled_meeting_hash_id = scheduled_meetings.hash_id
+      FROM scheduled_meetings
+      WHERE scheduled_meeting_hash_id = CAST (scheduled_meetings.id AS TEXT)
+    SQL
+
+    execute(query)
+  end
+
+  def down
+    query = <<-SQL
+      UPDATE brightspace_calendar_events
+      SET scheduled_meeting_hash_id = CAST (scheduled_meetings.id AS TEXT)
+      FROM scheduled_meetings
+      WHERE scheduled_meeting_hash_id = scheduled_meetings.hash_id
+    SQL
+
+    execute(query)
+
+    rename_column :brightspace_calendar_events,
+                  :scheduled_meeting_hash_id,
+                  :scheduled_meeting_id
+    change_column :brightspace_calendar_events,
+                  :scheduled_meeting_id,
+                  'bigint USING scheduled_meeting_id::bigint'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_01_210533) do
+ActiveRecord::Schema.define(version: 2021_07_06_140832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 2021_06_01_210533) do
 
   create_table "brightspace_calendar_events", force: :cascade do |t|
     t.integer "event_id"
-    t.bigint "scheduled_meeting_id"
+    t.string "scheduled_meeting_hash_id"
     t.bigint "room_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 2021_06_01_210533) do
     t.index ["event_id", "room_id"], name: "index_brightspace_calendar_events_on_event_id_and_room_id", unique: true
     t.index ["link_id", "room_id"], name: "index_brightspace_calendar_events_on_link_id_and_room_id", unique: true
     t.index ["room_id"], name: "index_brightspace_calendar_events_on_room_id"
-    t.index ["scheduled_meeting_id"], name: "index_brightspace_calendar_events_on_scheduled_meeting_id"
+    t.index ["scheduled_meeting_hash_id"], name: "index_brightspace_calendar_events_on_scheduled_meeting_hash_id"
   end
 
   create_table "consumer_config_brightspace_oauths", force: :cascade do |t|


### PR DESCRIPTION
The parameter passed in the URL (send_calendar_update_event, etc.) is a
hash_id due to previous changes.
BrightspaceCalendarEvent was storing the scheduled_meeting_id instead of
the scheduled_meeting_hash_id and the event was never found.

It was necessary to change the event model to store the hash_id because the
schedule_meeting object doens't exist in the DB anymore when the
action is called.