### PR TITLE
LTI-100 Upgrade bigbluebutton-api-ruby gem to 1.8.0 from 1.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,8 +83,8 @@ gem 'jquery-fileupload-rails'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
 
-# API
-gem 'bigbluebutton-api-ruby'
+# BigBlueButton API
+gem 'bigbluebutton-api-ruby', '~> 1.8'
 
 # AWS S3 API (to access Spaces API)
 gem 'aws-sdk-s3', '~> 1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,13 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    bigbluebutton-api-ruby (1.7.0)
+    bigbluebutton-api-ruby (1.8.0)
+      childprocess (>= 1.0.1)
+      ffi (>= 1.9.24)
+      json (>= 1.8.6)
+      nokogiri (>= 1.10.4)
+      rack (>= 1.6.11)
+      rubyzip (>= 1.3.0)
       xml-simple (~> 1.1)
     bindex (0.8.1)
     bootsnap (1.4.6)
@@ -299,6 +305,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    rexml (3.2.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -390,7 +397,8 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xml-simple (1.1.8)
+    xml-simple (1.1.9)
+      rexml
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.2)
@@ -400,7 +408,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3 (~> 1)
-  bigbluebutton-api-ruby
+  bigbluebutton-api-ruby (~> 1.8)
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.5.0)
   browser

--- a/lib/bbb_api.rb
+++ b/lib/bbb_api.rb
@@ -163,8 +163,9 @@ module BbbApi
       secret = Rails.configuration.bigbluebutton_secret
     end
 
+    # BigBlueButtonApi.new(url, secret, version=nil, logger=nil)
     BigBlueButton::BigBlueButtonApi.new(
-      remove_slash(fix_bbb_endpoint_format(endpoint)), secret, "0.9", "true"
+      remove_slash(fix_bbb_endpoint_format(endpoint)), secret, "0.9", Rails.logger
     )
   end
 


### PR DESCRIPTION
This version replaces the `debug` flag with an option to pass the application's logger to the gem,
so they can share the same format and log_level.

Updated the `BigBlueButtonApi` initialization to pass the Rails logger.