### PR TITLE
LTI-3 Add spanish language

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -255,6 +255,8 @@ class ApplicationController < ActionController::Base
     case locale
     when /^pt/i
       I18n.locale = 'pt'
+    when /^es/i
+      I18n.locale = 'es'
     else
       I18n.locale = 'en' # fallback
     end

--- a/config/locales/es-rails-i18n.yml
+++ b/config/locales/es-rails-i18n.yml
@@ -1,0 +1,219 @@
+---
+es:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'La validación falló: %{errors}'
+        restrict_dependent_destroy:
+          has_one: No se puede eliminar el registro porque existe un %{record} dependiente
+          has_many: No se puede eliminar el registro porque existen %{record} dependientes
+  date:
+    abbr_day_names:
+    - dom
+    - lun
+    - mar
+    - mié
+    - jue
+    - vie
+    - sáb
+    abbr_month_names:
+    - 
+    - ene
+    - feb
+    - mar
+    - abr
+    - may
+    - jun
+    - jul
+    - ago
+    - sep
+    - oct
+    - nov
+    - dic
+    day_names:
+    - domingo
+    - lunes
+    - martes
+    - miércoles
+    - jueves
+    - viernes
+    - sábado
+    formats:
+      default: "%-d/%-m/%Y"
+      long: "%-d de %B de %Y"
+      short: "%-d de %b"
+    month_names:
+    - 
+    - enero
+    - febrero
+    - marzo
+    - abril
+    - mayo
+    - junio
+    - julio
+    - agosto
+    - septiembre
+    - octubre
+    - noviembre
+    - diciembre
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: alrededor de 1 hora
+        other: alrededor de %{count} horas
+      about_x_months:
+        one: alrededor de 1 mes
+        other: alrededor de %{count} meses
+      about_x_years:
+        one: alrededor de 1 año
+        other: alrededor de %{count} años
+      almost_x_years:
+        one: casi 1 año
+        other: casi %{count} años
+      half_a_minute: medio minuto
+      less_than_x_seconds:
+        one: menos de 1 segundo
+        other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
+      over_x_years:
+        one: más de 1 año
+        other: más de %{count} años
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
+      x_minutes:
+        one: 1 minuto
+        other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
+      x_months:
+        one: 1 mes
+        other: "%{count} meses"
+      x_years:
+        one: 1 año
+        other: "%{count} años"
+    prompts:
+      second: Segundo
+      minute: Minuto
+      hour: Hora
+      day: Día
+      month: Mes
+      year: Año
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: debe ser aceptado
+      blank: no puede estar en blanco
+      confirmation: no coincide
+      empty: no puede estar vacío
+      equal_to: debe ser igual a %{count}
+      even: debe ser par
+      exclusion: está reservado
+      greater_than: debe ser mayor que %{count}
+      greater_than_or_equal_to: debe ser mayor que o igual a %{count}
+      inclusion: no está incluido en la lista
+      invalid: no es válido
+      less_than: debe ser menor que %{count}
+      less_than_or_equal_to: debe ser menor que o igual a %{count}
+      model_invalid: 'La validación falló: %{errors}'
+      not_a_number: no es un número
+      not_an_integer: debe ser un entero
+      odd: debe ser impar
+      other_than: debe ser distinto de %{count}
+      present: debe estar en blanco
+      required: debe existir
+      taken: ya está en uso
+      too_long:
+        one: es demasiado largo (1 carácter máximo)
+        other: es demasiado largo (%{count} caracteres máximo)
+      too_short:
+        one: es demasiado corto (1 carácter mínimo)
+        other: es demasiado corto (%{count} caracteres mínimo)
+      wrong_length:
+        one: no tiene la longitud correcta (1 carácter exactos)
+        other: no tiene la longitud correcta (%{count} caracteres exactos)
+    template:
+      body: 'Se encontraron problemas con los siguientes campos:'
+      header:
+        one: No se pudo guardar este/a %{model} porque se encontró 1 error
+        other: No se pudo guardar este/a %{model} porque se encontraron %{count} errores
+  helpers:
+    select:
+      prompt: Por favor seleccione
+    submit:
+      create: Crear %{model}
+      submit: Guardar %{model}
+      update: Actualizar %{model}
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " y "
+      two_words_connector: " y "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%A, %-d de %B de %Y %H:%M:%S %z"
+      long: "%-d de %B de %Y %H:%M"
+      short: "%-d de %b %H:%M"
+    pm: pm

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,179 @@
+es:
+  default:
+    app:
+      bigbluebutton_error: "Error de comunicación con el servidor de conferencias. Inténtelo de nuevo o contáctenos. (%{status})"
+      spaces_error:   "Error de comunicación con el servidor de almacenamiento de informes. Inténtelo de nuevo o contáctenos."
+      error:          "Error"
+    admin:
+      back:           "Vuelve"
+      handler:        "Handler"
+      newroom:        "Nueva sala"
+      showall:        "Ver todo"
+      showroom:
+        text:         "Exhibir"
+      editroom:
+        text:         "Editar"
+      destroyroom:
+        text:         "Eliminar"
+        confirmation: "¿Estás seguro de que deseas eliminar esta sala?"
+    bigbluebutton:
+      moderator:      "Moderador"
+      viewer:         "Participante"
+    room:
+      cancel:         "Cancelar"
+      created:        "La sala se creó con éxito"
+      description:    "Descripción"
+      destroy:        "Eliminar"
+      destroyed:      "La sala se ha eliminado correctamente"
+      edit:           "Editar"
+      editing:        "Editando sala"
+      error:
+        oauth:        "Se produjo un error al autorizar a través de OAuth."
+      join:           "Iniciar sesión"
+      moderator:      "Clave de moderador"
+      name:           "Nombre"
+      recordings:     "Grabaciones"
+      scheduled_meetings: "Sesiones programadas"
+      show:           "Exhibir"
+      showing:        "Visualización de sala"
+      update:         "Actualizar"
+      updated:        "Actualizado"
+      viewer:         "Clave de participante"
+      waitmodmsg:     "Por favor, espere hasta que un moderador entre en la sala. Serás redirigido automáticamente."
+      welcome:        "Bienvenida"
+    meeting:
+      close:           "Cerrar ventana"
+      close_manually:  "Esta ventana debe cerrarse manualmente"
+    scheduled_meeting:
+      allmoderators:  "Todos moderadores"
+      calendar:
+        description:
+          link:       "Haga clic aquí para acceder a esta clase."
+      created:        "La sesión ha sido programada"
+      destroy:
+        confirmation: "¿Está seguro de que desea eliminar esta programación?"
+      destroyed:      "La programación fue eliminada"
+      durations:
+        5m: "5 minutos"
+        10m: "10 minutos"
+        15m: "15 minutos"
+        20m: "20 minutos"
+        30m: "30 minutos"
+        45m: "45 minutos"
+        1h: "1 hora"
+        2h: "2 horas"
+        3h: "3 horas"
+        4h: "4 horas"
+        5h: "5 horas"
+        6h: "6 horas"
+        8h: "8 horas"
+        12h: "12 horas"
+        24h: "24 horas"
+        'Custom Duration': "Duración personalizada"
+      edit:           "Editar"
+      error:
+        invalid_start_at: "La fecha u hora de inicio no es válida"
+      external:
+        ended:        "Esta sesión ya terminó."
+        first_name:   "Primer nombre"
+        join:         "Entrar"
+        last_name:    "Apellido"
+      recording:      "Grabación"
+      repeat_options:
+        none: "No repite"
+        weekly: "Semanal"
+        every_two_weeks: "Quincenal"
+      tooltip:
+        recording:    "La sesión se puede grabar"
+        waitmoderator: "Los participantes no pueden ingresar hasta que ingrese un moderador"
+        allmoderators: "Todos los usuarios serán moderadores"
+      updated:        "La programación ha sido actualizada"
+      wait:
+        message: "Hola <strong>%{name}</strong>, la sesión aún no ha comenzado. </br> Espere unos minutos."
+        message_auto: "Hola <strong>%{name}</strong>, se está creando su sesión, por favor espere unos momentos."
+      waitmoderator:  "Espera al moderador"
+    session:
+      retry:
+        alternatives:
+          title: "Si desea probar otras alternativas, puede:"
+          a: "Utilice su navegador en modo normal (no anónimo)"
+          b: "Compruebe si su navegador tiene habilitadas las cookies."
+          c: "Deshabilite los plugins, especialmente los bloqueadores de anuncios."
+        description: "Esto suele ocurrir porque su navegador está bloqueando el acceso. Intente acceder en una nueva ventana usando el botón de abajo:"
+        launch_btn: "Abrir en nueva ventana"
+        title: "No pudimos autenticar su acceso"
+    formats:
+      flatpickr:
+        date_js: "d/m/Y"
+        date_ruby: "%d/%m/%Y"
+        time_js: "H:i"
+        time_ruby: "%H:%M"
+  error:
+    ops: "Uy!"
+    http:
+      _401:
+        code:       "Unauthorized"
+        message:    "Autenticación fallida."
+        suggestion: "Parece que no puedes iniciar sesión aquí."
+        explanation: "Si cree que se trata de un error, intente iniciar la sala nuevamente en su LMS o intente actualizar esta página en su navegador."
+        status_code: "401"
+      _404:
+        code:       "NotFound"
+        message:    "Esta página no existe."
+        suggestion: "Parece que no hay nada aquí."
+        status_code: "404"
+    bigbluebutton:
+      invalid_request:
+        code:        "BBBAPICallInvalid"
+        message:     "falla del servidor"
+        suggestion:  "Llamada no válida a BigBlueButton"
+        explanation: "Asegúrese de que el servidor de BigBlueButton que está utilizando esté disponible y accesible para el servidor donde está instalada la aplicación LTI."
+        status_code: "500"
+    generic:
+      404:
+        code:       "NotFound"
+        message:    "Esta página no existe."
+        suggestion: "Parece que no hay nada aquí."
+      406:
+        code:       "NotAcceptable"
+        message:    "Formato no compatible"
+        suggestion: "La URL que ingresaste probablemente sea incorrecta."
+        status_code: "406"
+      500:
+        code: "ServerError"
+        message: "Falla del servidor."
+        suggestion: "Parece que algo se rompió."
+        explanation: "Ya estamos trabajando para reparar esto."
+        status_code: "500"
+    room:
+      forbidden:
+        code:        "AccessForbidden"
+        message:     "Acceso no permitido."
+        suggestion:  "La sesión ha expirado"
+        explanation: "Si está utilizando esta sala a través de LTI, intente iniciar la sala nuevamente en su LMS o intente actualizar esta página en su navegador."
+        status_code: "403"
+      not_found:
+        code:       "NotFound"
+        message:    "Sala no encontrada"
+        suggestion: "No se encontró la sala a la que intentó acceder."
+        status_code: "404"
+      invalid_secret:
+        code:        "InvalidSecret"
+        message:     "Acceso no permitido."
+        suggestion:  "No se puede verificar el token"
+        explanation: "El problema puede deberse al uso de una clave no válida para validar la solicitud realizada por el proveedor de LTI."
+        status_code: "403"
+    scheduled_meeting:
+      not_found:
+        code:        "NotFound"
+        message:     "Reunión no encontrada"
+        suggestion:  "No se encontró la programación"
+        explanation: "Es posible que el creador de la sesión lo haya eliminado."
+        status_code: "404"
+  views:
+    pagination:
+      first: "&laquo;"
+      last: "&raquo;"
+      previous: "&lsaquo;"
+      next: "&rsaquo;"
+      truncate: "&hellip;"

--- a/themes/elos/config/locales/es.yml
+++ b/themes/elos/config/locales/es.yml
@@ -1,0 +1,107 @@
+es:
+  _all:
+    cancel: "Cancelar"
+    clipboard:
+      link_copied: "Link copiado al clipboard!"
+    schedule: "Agendar"
+  helpers:
+    distance_of_time_in_hours_and_minutes:
+      hour:
+        one: "%{count} hora"
+        other: "%{count} horas"
+      minute:
+        one: "%{count} minuto"
+        other: "%{count} minutos"
+      connector: "y"
+    hint:
+      disable_external_link: "El acceso a la sala virtual estará restringido a estudiantes autenticados."
+      disable_private_chat: "El estudiante aún puede enviar mensajes privados al maestro. Esta función se puede reactivar dentro de la habitación a través de la opción \"Restringir participantes\"."
+      disable_note: "El profesor aún puede usar las notas compartidas, pero los estudiantes solo pueden ver el contenido, no editarlo. Esta función se puede reactivar dentro de la habitación a través de la opción \"Restringir participantes\"."
+      repeat: "El enlace externo para una programación periódica siempre será el mismo. El nuevo horario aparecerá en la lista una vez finalizado el actual."
+      time: "Estás usando la zona horaria: %{zone}"
+      custom_duration: "Elija la duración de la sesión: HH:MM"
+    label:
+      scheduled_meeting:
+        all_moderators: "Todos entran como moderadores."
+        custom_duration: "Duración personalizada"
+        description: "Descripción (opcional)"
+        disable_external_link: "Deshabilitar enlace externo"
+        disable_private_chat: "Deshabilitar chats privados"
+        disable_note: "Deshabilitar notas compartidas"
+        duration: "Duración"
+        name: "Nombre de la sesión"
+        recording: "Permitir que se grabe la sesión"
+        repeat: "Recurrencia"
+        start_time: "Fecha y hora de inicio"
+        start_time_date: "Data"
+        start_time_time: "Hora de inicio"
+        wait_moderator: "Espere a que ingrese el moderador para entrar"
+        welcome: "Mensaje de bienvenida (opcional)"
+  recordings:
+    all_loaded: "Todas las grabaciones cargadas"
+    confirm:
+      destroy: "¿Estás seguro de que deseas eliminar esta grabación?"
+      publish: "¿Estás seguro de que quieres publicar esta grabación?"
+      unpublish: "¿Estás seguro de que deseas anular la publicación de esta grabación?"
+    destroy: "Eliminar"
+    duration:
+      less_than_a_minute: "Menos de 1 minuto"
+    empty_list: "No hay grabaciones para mostrar"
+    index:
+      return: "< volver"
+    load: "Cargar más grabaciones"
+    playback_link: "Copiar enlace de reproducción"
+    playbacks:
+      presentation: "Reproducir"
+      presentation_video: "Descargar"
+    publish: "Publicar"
+    search:
+      placeholder: "Buscar en título o descripción..."
+    table:
+      footnote: "Fechas mostradas en la zona horaria: %{zone}"
+    title: "Grabaciones"
+    unpublish: "Anular publicación"
+  reports:
+    download: "Descargar"
+    download_options:
+      csv: "Planilla de reuniones (CSV)"
+      xls: "Planilla de reuniones (Excel XLS)"
+    empty_list: "No se encontraron informes :("
+    index:
+      return: "< volver"
+    table_footnote: "Los informes del mes actual se actualizan diariamente."
+    title: "Informes"
+    view_reports: "Ver informes"
+  rooms:
+    close:
+      message: "Gracias por su participación y hasta luego."
+      title: "Tu sesión ha terminado"
+  scheduled_meetings:
+    destroy: "Eliminar"
+    edit:
+      action: "Editar"
+      title: "Editar sesión"
+    empty_list: "No hay sesiones programadas para mostrar"
+    external_link: "Copiar enlace externo"
+    new:
+      add: "+ Programar sesión"
+      title: "Programar sesión"
+    show:
+      view_recordings: "Ver grabaciones"
+    table:
+      footnote: "Fechas mostradas en la zona horaria: %{zone}"
+    title: "Sesiones programadas"
+    wait:
+      retry: "Entrar"
+  time:
+    am: am
+    formats:
+      short_custom: "%d/%m/%Y %H:%M"
+  datetime:
+    distance_in_words:
+      x_hours:
+        one: 'an hour'
+        other: '%{count} hours'
+  terms:
+    message: "Al hacer clic en <em>%{enter_room}</em>, acepta nuestros <a href='%{link}' target='_blank'>términos y condiciones</a>."
+    enter_room: "Entrar"

--- a/themes/elos/config/locales/es.yml
+++ b/themes/elos/config/locales/es.yml
@@ -19,7 +19,7 @@ es:
       disable_note: "El profesor aún puede usar las notas compartidas, pero los estudiantes solo pueden ver el contenido, no editarlo. Esta función se puede reactivar dentro de la habitación a través de la opción \"Restringir participantes\"."
       repeat: "El enlace externo para una programación periódica siempre será el mismo. El nuevo horario aparecerá en la lista una vez finalizado el actual."
       time: "Estás usando la zona horaria: %{zone}"
-      custom_duration: "Elija la duración de la sesión: HH:MM"
+      custom_duration: "Informe la duración de la sesión: HH:MM"
     label:
       scheduled_meeting:
         all_moderators: "Todos entran como moderadores."
@@ -38,7 +38,7 @@ es:
         wait_moderator: "Espere a que ingrese el moderador para entrar"
         welcome: "Mensaje de bienvenida (opcional)"
   recordings:
-    all_loaded: "Todas las grabaciones cargadas"
+    all_loaded: "Se han cargado todas las grabaciones"
     confirm:
       destroy: "¿Estás seguro de que deseas eliminar esta grabación?"
       publish: "¿Estás seguro de que quieres publicar esta grabación?"
@@ -104,4 +104,4 @@ es:
         other: '%{count} hours'
   terms:
     message: "Al hacer clic en <em>%{enter_room}</em>, acepta nuestros <a href='%{link}' target='_blank'>términos y condiciones</a>."
-    enter_room: "Entrar"
+    enter_room: "Acceder"

--- a/themes/rnp/config/locales/es.yml
+++ b/themes/rnp/config/locales/es.yml
@@ -1,0 +1,107 @@
+es:
+  _all:
+    cancel: "Cancelar"
+    clipboard:
+      link_copied: "Link copiado al clipboard!"
+    schedule: "Agendar"
+  helpers:
+    distance_of_time_in_hours_and_minutes:
+      hour:
+        one: "%{count} hora"
+        other: "%{count} horas"
+      minute:
+        one: "%{count} minuto"
+        other: "%{count} minutos"
+      connector: "y"
+    hint:
+      disable_external_link: "El acceso a la sala virtual estará restringido a estudiantes autenticados."
+      disable_private_chat: "El estudiante aún puede enviar mensajes privados al maestro. Esta función se puede reactivar dentro de la habitación a través de la opción \"Restringir participantes\"."
+      disable_note: "El profesor aún puede usar las notas compartidas, pero los estudiantes solo pueden ver el contenido, no editarlo. Esta función se puede reactivar dentro de la habitación a través de la opción \"Restringir participantes\"."
+      repeat: "El enlace externo para una programación periódica siempre será el mismo. El nuevo horario aparecerá en la lista una vez finalizado el actual."
+      time: "Estás usando la zona horaria: %{zone}"
+      custom_duration: "Informe la duración de la sesión: HH:MM"
+    label:
+      scheduled_meeting:
+        all_moderators: "Todos entran como moderadores."
+        custom_duration: "Duración personalizada"
+        description: "Descripción (opcional)"
+        disable_external_link: "Deshabilitar enlace externo"
+        disable_private_chat: "Deshabilitar chats privados"
+        disable_note: "Deshabilitar notas compartidas"
+        duration: "Duración"
+        name: "Nombre de la sesión"
+        recording: "Permitir que se grabe la sesión"
+        repeat: "Recurrencia"
+        start_time: "Fecha y hora de inicio"
+        start_time_date: "Data"
+        start_time_time: "Hora de inicio"
+        wait_moderator: "Espere a que ingrese el moderador para entrar"
+        welcome: "Mensaje de bienvenida (opcional)"
+  recordings:
+    all_loaded: "Se han cargado todas las grabaciones"
+    confirm:
+      destroy: "¿Estás seguro de que deseas eliminar esta grabación?"
+      publish: "¿Estás seguro de que quieres publicar esta grabación?"
+      unpublish: "¿Estás seguro de que deseas anular la publicación de esta grabación?"
+    destroy: "Eliminar"
+    duration:
+      less_than_a_minute: "Menos de 1 minuto"
+    empty_list: "No hay grabaciones para mostrar"
+    index:
+      return: "< volver"
+    load: "Cargar más grabaciones"
+    playback_link: "Copiar enlace de reproducción"
+    playbacks:
+      presentation: "Reproducir"
+      presentation_video: "Descargar"
+    publish: "Publicar"
+    search:
+      placeholder: "Buscar en título o descripción..."
+    table:
+      footnote: "Fechas mostradas en la zona horaria: %{zone}"
+    title: "Grabaciones"
+    unpublish: "Anular publicación"
+  reports:
+    download: "Descargar"
+    download_options:
+      csv: "Planilla de reuniones (CSV)"
+      xls: "Planilla de reuniones (Excel XLS)"
+    empty_list: "No se encontraron informes :("
+    index:
+      return: "< volver"
+    table_footnote: "Los informes del mes actual se actualizan diariamente."
+    title: "Informes"
+    view_reports: "Ver informes"
+  rooms:
+    close:
+      message: "Gracias por su participación y hasta luego."
+      title: "Tu sesión ha terminado"
+  scheduled_meetings:
+    destroy: "Eliminar"
+    edit:
+      action: "Editar"
+      title: "Editar sesión"
+    empty_list: "No hay sesiones programadas para mostrar"
+    external_link: "Copiar enlace externo"
+    new:
+      add: "+ Programar sesión"
+      title: "Programar sesión"
+    show:
+      view_recordings: "Ver grabaciones"
+    table:
+      footnote: "Fechas mostradas en la zona horaria: %{zone}"
+    title: "Sesiones programadas"
+    wait:
+      retry: "Entrar"
+  time:
+    am: am
+    formats:
+      short_custom: "%d/%m/%Y %H:%M"
+  datetime:
+    distance_in_words:
+      x_hours:
+        one: 'an hour'
+        other: '%{count} hours'
+  terms:
+    message: "Al hacer clic en <em>%{enter_room}</em>, acepta nuestros <a href='%{link}' target='_blank'>términos y condiciones</a>."
+    enter_room: "Acceder"


### PR DESCRIPTION
- Added Spanish language locale recognition in `controllers/application_controller.rb`
- Added 3 locale files - `config/locales/es-rails-i18n.yml`, with standard rails i18n translations, `config/locales/es.yml` and `themes/elos/config/locales/es.yml`, with specific translations for the application.