### PR TITLE
LTI-104 - Click fix open conference in new tab

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,7 @@ Rails.application.routes.draw do
 
         resources :scheduled_meetings, only: [:new, :create, :edit, :update, :destroy] do
           member do
-            post :join
+            get :join
             get :external
             get :wait
             get :running

--- a/themes/coc/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/coc/views/shared/_scheduled_meeting_row.html.erb
@@ -24,8 +24,7 @@
   </td>
   <td class="col-12 col-md-1 align-middle">
     <%=
-    link_to join_room_scheduled_meeting_path(room, meeting), method: :post,
-     class: "btn btn-primary join-room-btn", target: '_blank' do
+      link_to join_room_scheduled_meeting_path(room, meeting), class: "btn btn-primary join-room-btn", target: '_blank' do
     %>
       <i class="icon material-icons">play_arrow</i>
     <% end %>

--- a/themes/elos/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/elos/views/shared/_scheduled_meeting_row.html.erb
@@ -21,8 +21,7 @@
   </td>
   <td class="col-12 col-md-1 align-middle">
     <%=
-    link_to join_room_scheduled_meeting_path(room, meeting), method: :post,
-     class: "btn btn-primary join-room-btn", target: '_blank' do
+      link_to join_room_scheduled_meeting_path(room, meeting), class: "btn btn-primary join-room-btn", target: '_blank' do
     %>
       <i class="icon material-icons">play_arrow</i>
     <% end %>

--- a/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
@@ -21,8 +21,7 @@
   </td>
   <td class="col-12 col-md-1 align-middle">
     <%=
-    link_to join_room_scheduled_meeting_path(room, meeting), method: :post,
-     class: "btn btn-primary join-room-btn", target: '_blank' do
+      link_to join_room_scheduled_meeting_path(room, meeting), class: "btn btn-primary join-room-btn", target: '_blank' do
     %>
       <i class="icon material-icons">play_arrow</i>
     <% end %>


### PR DESCRIPTION
Route `/join` modified from post to get.
When clicking open in new tab, the browser wait for a `get` request, but the route was set as post


