### PR TITLE
LTI-104 - Click fix open conference in new tab

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
 
         resources :scheduled_meetings, only: [:new, :create, :edit, :update, :destroy] do
           member do
+            post :join
             get :join
             get :external
             get :wait


### PR DESCRIPTION
Add route `/post` because it is used for external access (`/external`)
