### PR TITLE
LTI-70 - Fixes v0.5.0

### DIFF
--- a/themes/coc/assets/javascripts/schedule-coc.js
+++ b/themes/coc/assets/javascripts/schedule-coc.js
@@ -5,7 +5,7 @@ $(document).on('turbolinks:load', function(){
     var valueSelect = document.getElementsByName("scheduled_meeting[duration]")[0],
       contentCustomDuration = document.getElementById("content_custom_duration")
 
-    valueSelect.addEventListener('change', controlCustomDuration)
+    valueSelect?.addEventListener('change', controlCustomDuration)
     function controlCustomDuration(e) {
       let valueSelectDuration = e.target.value;
       valueSelectDuration == 0 ? contentCustomDuration.classList.add('d-block') :

--- a/themes/elos/assets/javascripts/schedule-elos.js
+++ b/themes/elos/assets/javascripts/schedule-elos.js
@@ -3,7 +3,7 @@ $(document).on('turbolinks:load', function(){
     var valueSelect = document.getElementsByName("scheduled_meeting[duration]")[0],
       contentCustomDuration = document.getElementById("content_custom_duration")
 
-    valueSelect.addEventListener('change', controlCustomDuration)
+    valueSelect?.addEventListener('change', controlCustomDuration)
     function controlCustomDuration(e) {
       let valueSelectDuration = e.target.value;
       valueSelectDuration == 0 ? contentCustomDuration.classList.add('d-block') :

--- a/themes/elos/views/scheduled_meetings/wait.html.erb
+++ b/themes/elos/views/scheduled_meetings/wait.html.erb
@@ -3,11 +3,8 @@
      data-meeting-id="<%= @scheduled_meeting.to_param %>"
      data-join-url="<%= join_room_scheduled_meeting_path(@room, @scheduled_meeting) %>"
      data-wait-url="<%= running_room_scheduled_meeting_path(@room, @scheduled_meeting) %>"
-     data-wait-interval="<%= Rails.configuration.cable_polling_secs %>"
-     data-btn-timeout="<%= Rails.configuration.cable_btn_timeout %>"
      data-is-running="<%= @is_running %>"
-     data-auto="<%= @auto_join %>"
-     data-join-method="post">
+     data-auto="<%= @auto_join %>">
 
   <%= image_tag 'guest-wait.svg' %>
   <p>

--- a/themes/rnp/assets/javascripts/schedule-rnp.js
+++ b/themes/rnp/assets/javascripts/schedule-rnp.js
@@ -3,7 +3,7 @@ $(document).on('turbolinks:load', function(){
     var valueSelect = document.getElementsByName("scheduled_meeting[duration]")[0],
       contentCustomDuration = document.getElementById("content_custom_duration")
 
-    valueSelect.addEventListener('change', controlCustomDuration)
+    valueSelect?.addEventListener('change', controlCustomDuration)
     function controlCustomDuration(e) {
       let valueSelectDuration = e.target.value;
       valueSelectDuration == 0 ? contentCustomDuration.classList.add('d-block') :

--- a/themes/rnp/views/scheduled_meetings/wait.html.erb
+++ b/themes/rnp/views/scheduled_meetings/wait.html.erb
@@ -3,11 +3,8 @@
      data-meeting-id="<%= @scheduled_meeting.to_param %>"
      data-join-url="<%= join_room_scheduled_meeting_path(@room, @scheduled_meeting) %>"
      data-wait-url="<%= running_room_scheduled_meeting_path(@room, @scheduled_meeting) %>"
-     data-wait-interval="<%= Rails.configuration.cable_polling_secs %>"
-     data-btn-timeout="<%= Rails.configuration.cable_btn_timeout %>"
      data-is-running="<%= @is_running %>"
-     data-auto="<%= @auto_join %>"
-     data-join-method="post">
+     data-auto="<%= @auto_join %>">
 
   <%= image_tag 'guest-wait.svg' %>
   <p>


### PR DESCRIPTION
Remove olds metadata that was no longer being used;
Fix bug in browser console, was trying to add an `addEventListener` on a a non-existent element

