### PR TITLE
LTI-112: `start_ngrok.sh` support for ngrok v3.x

### DIFF
--- a/scripts/ngrok_start.sh
+++ b/scripts/ngrok_start.sh
@@ -57,8 +57,8 @@ start_ngrok() {
 
   # cat -v is used to read binary files
   # grep will search for the regex and will return anything after \K
-  address0_cmd="cat -v $ngrok_log | grep -Po \"msg=\\\"started tunnel\\\".*localhost:$port0.*url=http[s]?://\K.*\.ngrok\.io\""
-  address1_cmd="cat -v $ngrok_log | grep -Po \"msg=\\\"started tunnel\\\".*localhost:$port1.*url=http[s]?://\K.*\.ngrok\.io\""
+  address0_cmd="cat -v $ngrok_log | grep -Po \"msg=\\\"started tunnel\\\".*localhost:$port0.*url=http[s]://\K.*\.ngrok\.io\""
+  address1_cmd="cat -v $ngrok_log | grep -Po \"msg=\\\"started tunnel\\\".*localhost:$port1.*url=http[s]://\K.*\.ngrok\.io\""
 
   address0=$(eval $address0_cmd)
   address1=$(eval $address1_cmd)

--- a/scripts/ngrok_start.sh
+++ b/scripts/ngrok_start.sh
@@ -26,7 +26,15 @@ port0="3000"
 port1="3001"
 
 start_ngrok() {
-  ngrok_log="$HOME/.ngrok2/ngrok.log"
+  ngrok_version=$(ngrok --version | grep -Po '(?<= )([0-9])(?=\.)')
+
+  if [ "$ngrok_version" = "3" ];
+  then
+    ngrok_log="$HOME/.config/ngrok/ngrok.log"
+  else
+    ngrok_log="$HOME/.ngrok2/ngrok.log"
+  fi
+
   ngrok_is_running=false
   if [ $(ps -e | grep -Po "\s+ngrok\s*$" | wc -l) -gt 0 ];
   then
@@ -49,8 +57,8 @@ start_ngrok() {
 
   # cat -v is used to read binary files
   # grep will search for the regex and will return anything after \K
-  address0_cmd="cat -v $ngrok_log | grep -Po \"msg=\\\"started tunnel\\\".*localhost:$port0.*url=http://\K.*\.ngrok\.io\""
-  address1_cmd="cat -v $ngrok_log | grep -Po \"msg=\\\"started tunnel\\\".*localhost:$port1.*url=http://\K.*\.ngrok\.io\""
+  address0_cmd="cat -v $ngrok_log | grep -Po \"msg=\\\"started tunnel\\\".*localhost:$port0.*url=http[s]?://\K.*\.ngrok\.io\""
+  address1_cmd="cat -v $ngrok_log | grep -Po \"msg=\\\"started tunnel\\\".*localhost:$port1.*url=http[s]?://\K.*\.ngrok\.io\""
 
   address0=$(eval $address0_cmd)
   address1=$(eval $address1_cmd)


### PR DESCRIPTION
Couple of modifications on the `start_ngrok.sh` script to run as expected if the ngrok's version is `3.x`:
* The path to the ngrok.log file was changed to the be created on the same path as the ngrok's config file;
* When reading from the log file, the ngrok's URL protocol now can be either HTTP or HTTPS.