### PR TITLE
[LTI-105] Add COC origin to meetings

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -206,7 +206,7 @@ class RoomsController < ApplicationController
   end
 
   def set_room_title
-    if @app_launch&.tag == 'coc'
+    if @app_launch&.coc_launch?
       @title = @room.name
       @subtitle = @room.description
     end

--- a/app/models/app_launch.rb
+++ b/app/models/app_launch.rb
@@ -30,6 +30,10 @@ class AppLaunch < ApplicationRecord
     params['custom_params']['tag']
   end
 
+  def coc_launch?
+    self.tag == 'coc'
+  end
+
   def user_params
     {
       uid: self.params['user_id'],

--- a/app/models/scheduled_meeting.rb
+++ b/app/models/scheduled_meeting.rb
@@ -123,10 +123,11 @@ class ScheduledMeeting < ApplicationRecord
     # set the duration + 1h if configured to do so in the consumer
     config = ConsumerConfig.select(:set_duration).find_by(key: self.room.consumer_key)
     opts[:duration] = duration_minutes + 60 if !config.blank? && config.set_duration
+    launch_params = AppLaunch.find_by(nonce: user.launch_nonce)
 
     # will be added as meta_bbb-*
     meta_bbb = {
-      origin: 'LTI',
+      origin: launch_params&.coc_launch? ? 'Portal COC' : 'LTI',
       'recording-name': self.name,
       'recording-description': self.description,
       'room-handler': self.room.handler,
@@ -134,7 +135,6 @@ class ScheduledMeeting < ApplicationRecord
     }
 
     # extra launch params, if we can found them
-    launch_params = AppLaunch.find_by(nonce: user.launch_nonce)
     if launch_params.present?
       meta_bbb.merge!(
         {

--- a/spec/models/app_launch_spec.rb
+++ b/spec/models/app_launch_spec.rb
@@ -7,4 +7,20 @@ RSpec.describe AppLaunch, type: :model do
     expect(FactoryBot.build(:app_launch)).to be_valid
   end
 
+  describe '#coc_launch?' do
+    context "when the custom_params's tag equals 'coc'" do
+      subject { FactoryBot.create(:app_launch, params: { custom_params: { tag: 'coc' } }) }
+      it { expect(subject.coc_launch?).to eql(true) }
+    end
+
+    context "when the custom_params's tag doesn't equals 'coc'" do
+      subject { FactoryBot.create(:app_launch, params: { custom_params: { tag: 'something' } }) }
+      it { expect(subject.coc_launch?).to eql(false) }
+    end
+
+    context "when the custom_params don't include a tag" do
+      subject { FactoryBot.create(:app_launch, params: { custom_params: {} }) }
+      it { expect(subject.coc_launch?).to eql(false) }
+    end
+  end
 end


### PR DESCRIPTION
Set 'Portal COC' as origin for COC's meetings.
Uses the new `coc_launch?` method to check if the app_launch is from COC portal.