### PR TITLE
LTI-136: Fixes v0.9.0

### DIFF
--- a/app/assets/javascripts/meetings.js
+++ b/app/assets/javascripts/meetings.js
@@ -18,6 +18,7 @@ const $DOCUMENT = $(document);
 let isFetching = false;
 let hasMoreToFetch = true;
 let rendered = false;
+let loadedMeetingId = null;
 
 // Max time to wait for ajax response
 let ajaxTimeout = 5000;
@@ -238,24 +239,20 @@ let doAjaxBucket = async (check_bucket_endpoint) => {
  * In case of timeout, the timeout value will increase in 1 second.
 */
 let checkBucketFiles = async(meeting_id, check_bucket_endpoint) => {
-  let currentButtonsCount = 0;
-  try {
-    let response = await doAjaxBucket(check_bucket_endpoint);
-    response = $(response);
-
-    let buttons = response.filter('.button_to')
-    currentButtonsCount += buttons.length;
-    if (currentButtonsCount == 0) {
-    } else {
+  if (loadedMeetingId != meeting_id) {
+    try {
+      let response = await doAjaxBucket(check_bucket_endpoint);
+      response = $(response);
+  
+      loadedMeetingId = meeting_id;
+      let buttons = response.filter('.button_to')
       showDropdownItems(buttons);
-    }
-    currentButtonsCount = 0;
-    
-  } catch(err) {
-    if (err.statusText == 'timeout') {
-      ajaxTimeout += 1000;
-    } else {
-      console.error(`Unexpected error: ${err}`);
+    } catch(err) {
+      if (err.statusText == 'timeout') {
+        ajaxTimeout += 1000;
+      } else {
+        console.error(`Unexpected error: ${err}`);
+      }
     }
   }
 };
@@ -268,15 +265,16 @@ let showMeetings = (rows) => {
   $('.dropdown-opts-link').on('click', function(e) {
     checkBucketFiles(this.getAttribute('meeting-id'), this.getAttribute('check-bucket-files-endpoint'));
   });
-
 };
 
 let showDropdownItems = (buttons) => {
+  // Hide the loading items animation
+  $('.dropdown-item-loading').hide();
   // Remove only the items appended previously
   $('.dropdown-items .appended-item').remove();
 
   for (let button of buttons) {
-    $(button).addClass('appended-item');
+    $(button).addClass('appended-item rec-edit');
     $('.dropdown-items').append(button);
   }
 };

--- a/app/assets/javascripts/meetings.js
+++ b/app/assets/javascripts/meetings.js
@@ -222,9 +222,62 @@ let hideAll = () => {
   $tableFootnote.hide();
 };
 
+/* Request the bucket files partial to the server.
+*/
+let doAjaxBucket = async (check_bucket_endpoint) => {
+  return $.ajax({
+    url: check_bucket_endpoint,
+    type: "GET",
+    timeout: ajaxTimeout
+  });
+}
+
+/* Fetch the files from bucket and process the response
+ *
+ * In case of success, it will display the received partial.
+ * In case of timeout, the timeout value will increase in 1 second.
+*/
+let checkBucketFiles = async(meeting_id, check_bucket_endpoint) => {
+  let currentButtonsCount = 0;
+  try {
+    let response = await doAjaxBucket(check_bucket_endpoint);
+    response = $(response);
+
+    let buttons = response.filter('.button_to')
+    currentButtonsCount += buttons.length;
+    if (currentButtonsCount == 0) {
+    } else {
+      showDropdownItems(buttons);
+    }
+    currentButtonsCount = 0;
+    
+  } catch(err) {
+    if (err.statusText == 'timeout') {
+      ajaxTimeout += 1000;
+    } else {
+      console.error(`Unexpected error: ${err}`);
+    }
+  }
+};
+
 let showMeetings = (rows) => {
   for(let row of rows) {
     $meetingsTable.append(row)
+  }
+
+  $('.dropdown-opts-link').on('click', function(e) {
+    checkBucketFiles(this.getAttribute('meeting-id'), this.getAttribute('check-bucket-files-endpoint'));
+  });
+
+};
+
+let showDropdownItems = (buttons) => {
+  // Remove only the items appended previously
+  $('.dropdown-items .appended-item').remove();
+
+  for (let button of buttons) {
+    $(button).addClass('appended-item');
+    $('.dropdown-items').append(button);
   }
 };
 

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -86,7 +86,8 @@ class RoomsController < ApplicationController
 
   # GET /rooms/:id/recording/:record_id/playback/:playback_type
   def recording_playback
-    recording = get_recordings(@room, recordID: params[:record_id]).first
+    # get_recordings returns [[{rec_hash}], boolean]
+    recording = get_recordings(@room, recordID: params[:record_id]).first.first
     playback = recording[:playbacks].find { |p| p[:type] == params[:playback_type] }
     playback_url = URI.parse(playback[:url])
     if Rails.application.config.playback_url_authentication

--- a/themes/elos/config/locales/en.yml
+++ b/themes/elos/config/locales/en.yml
@@ -52,6 +52,8 @@ en:
     meeting_data_download:
       download_notes: "Download meeting's notes"
       download_participants: "Download participants list"
+      unavailable_notes: "Unavailable meeting's notes"
+      unavailable_participants: "Unavailable participants list"
     recording:
       confirm:
         destroy: "Are you sure you want to delete this recording?"

--- a/themes/elos/config/locales/es.yml
+++ b/themes/elos/config/locales/es.yml
@@ -52,6 +52,8 @@ es:
     meeting_data_download:
       download_notes: "Descargar notas de la reunión"
       download_participants: "Descargar lista de participantes"
+      unavailable_notes: "Notas de la reunión no disponibles"
+      unavailable_participants: "Lista de participantes no disponible"
     recording:
       confirm:
         destroy: "¿Estás seguro de que deseas eliminar esta grabación?"

--- a/themes/elos/config/locales/pt.yml
+++ b/themes/elos/config/locales/pt.yml
@@ -52,6 +52,8 @@ pt:
     meeting_data_download:
       download_notes: "Download das notas da reunião"
       download_participants: "Download da lista de participantes"
+      unavailable_notes: "Notas da reunião indisponíveis"
+      unavailable_participants: "Lista de participante indisponível"
     recording:
       confirm:
         destroy: "Você tem certeza que deseja deletar esta gravação?"

--- a/themes/elos/views/shared/_meeting_data_download.html.erb
+++ b/themes/elos/views/shared/_meeting_data_download.html.erb
@@ -5,7 +5,7 @@
   <% end %>
 <% else %>
   <%= button_to room_scheduled_meetings_path(@room), disabled: true, class: "dropdown-item rec-edit" do %>
-    <%= t('meetings.meeting_data_download.download_notes') %>
+    <%= t('meetings.meeting_data_download.unavailable_notes') %>
   <% end %>
 <% end %>
 
@@ -16,6 +16,6 @@
   <% end %>
 <% else %>
   <%= button_to room_scheduled_meetings_path(@room), disabled: true, class: "dropdown-item rec-edit" do %>
-    <%= t('meetings.meeting_data_download.download_participants') %>
+    <%= t('meetings.meeting_data_download.unavailable_participants') %>
   <% end %>
 <% end %>

--- a/themes/elos/views/shared/_meeting_data_download.html.erb
+++ b/themes/elos/views/shared/_meeting_data_download.html.erb
@@ -1,21 +1,21 @@
 <% if @notes_exist %>
   <%= link_to room_scheduled_meeting_internal_download_notes_path(@room, @meeting[:meetingID], @meeting[:internalMeetingID]),
-    target: '_blank', class: "dropdown-item rec-edit" do %>
+    method: :get, target: '_blank', class: "dropdown-item rec-edit" do %>
     <%= t('meetings.meeting_data_download.download_notes') %>
   <% end %>
 <% else %>
-  <%= button_to room_scheduled_meetings_path(@room), disabled: true, class: "dropdown-item rec-edit" do %>
+  <%= link_to room_scheduled_meetings_path(@room), disabled: true, class: "dropdown-item rec-edit" do %>
     <%= t('meetings.meeting_data_download.unavailable_notes') %>
   <% end %>
 <% end %>
 
 <% if @participants_exist %>
   <%= link_to room_scheduled_meeting_internal_download_participants_path(@room, @meeting[:meetingID], @meeting[:internalMeetingID]),
-    target: '_blank', class: "dropdown-item rec-edit" do %>
+    method: :get, target: '_blank', class: "dropdown-item rec-edit" do %>
     <%= t('meetings.meeting_data_download.download_participants') %>
   <% end %>
 <% else %>
-  <%= button_to room_scheduled_meetings_path(@room), disabled: true, class: "dropdown-item rec-edit" do %>
+  <%= link_to room_scheduled_meetings_path(@room), disabled: true, class: "dropdown-item rec-edit" do %>
     <%= t('meetings.meeting_data_download.unavailable_participants') %>
   <% end %>
 <% end %>

--- a/themes/elos/views/shared/_meeting_row.html.erb
+++ b/themes/elos/views/shared/_meeting_row.html.erb
@@ -138,6 +138,10 @@
 
               <%# Download notes and participants %>
               <div class="dropdown-divider"></div>
+              <div class="dropdown-item-loading">
+                <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_notes') %>
+                <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_participants') %>
+              </div>
             <% end %>
           </div>
         </div>
@@ -158,7 +162,12 @@
             data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= icon_options_dots%>
           </a>
-          <div class="dropdown-menu dropdown-menu-right dropdown-items" aria-labelledby="dropdown-opts-<%= meeting[:meetingID] %>"></div>
+          <div class="dropdown-menu dropdown-menu-right dropdown-items" aria-labelledby="dropdown-opts-<%= meeting[:meetingID] %>">
+            <div class="dropdown-item-loading">
+              <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_notes') %>
+              <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_participants') %>
+            </div>
+          </div>
         </div>
       <% end %>
     </td>

--- a/themes/elos/views/shared/_meeting_row.html.erb
+++ b/themes/elos/views/shared/_meeting_row.html.erb
@@ -85,10 +85,13 @@
     <td class="col-2 col-md-1 td-dropdown-opts">
       <% if recording[:state] != 'processing' && recording[:published] || can_edit?(user, room) %>
         <div class="dropdown dropdown-opts">
-          <a href="#" class="dropdown-toggle d-flex text-decoration-none" id="dropdown-opts-<%= recording[:recordID] %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a href="#" class="dropdown-toggle d-flex text-decoration-none dropdown-opts-link"
+            meeting-id="<%= meeting[:meetingID] %>" 
+            check-bucket-files-endpoint="<%= room_scheduled_meeting_internal_check_bucket_files_path(@room, meeting[:meetingID], meeting[:internalMeetingID]) %>"
+            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= icon_options_dots %>
           </a>
-          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown-opts-<%= recording[:recordID] %>">
+          <div class="dropdown-menu dropdown-menu-right dropdown-items" aria-labelledby="dropdown-opts-<%= recording[:recordID] %>">
 
             <%# Copy playback link %>
             <% if recording[:published] %>
@@ -135,10 +138,6 @@
 
               <%# Download notes and participants %>
               <div class="dropdown-divider"></div>
-              <%= render_async room_scheduled_meeting_internal_check_bucket_files_path(room, meeting[:meetingID], meeting[:internalMeetingID]) do %>
-                <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_notes') %>
-                <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_participants') %>
-              <% end %>
             <% end %>
           </div>
         </div>
@@ -153,17 +152,13 @@
     <td class="col-md-1 td-dropdown-opts">
       <% if can_edit?(user, room) %>
         <div class="dropdown dropdown-opts">
-          <a href="#" class="dropdown-toggle d-flex text-decoration-none" id="dropdown-opts-<%= meeting[:meetingID] %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <%= icon_options_dots %>
+          <a href="#" class="dropdown-toggle d-flex text-decoration-none dropdown-opts-link"
+            meeting-id="<%= meeting[:meetingID] %>" 
+            check-bucket-files-endpoint="<%= room_scheduled_meeting_internal_check_bucket_files_path(room, meeting[:meetingID], meeting[:internalMeetingID]) %>"
+            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= icon_options_dots%>
           </a>
-          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown-opts-<%= meeting[:meetingID] %>">
-
-          <%# Download notes and participants %>
-          <%= render_async room_scheduled_meeting_internal_check_bucket_files_path(room, meeting[:meetingID], meeting[:internalMeetingID]) do %>
-            <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_notes') %>
-            <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_participants') %>
-          <% end %>
-          </div>
+          <div class="dropdown-menu dropdown-menu-right dropdown-items" aria-labelledby="dropdown-opts-<%= meeting[:meetingID] %>"></div>
         </div>
       <% end %>
     </td>

--- a/themes/rnp/config/locales/en.yml
+++ b/themes/rnp/config/locales/en.yml
@@ -52,6 +52,8 @@ en:
     meeting_data_download:
       download_notes: "Download meeting's notes"
       download_participants: "Download participants list"
+      unavailable_notes: "Unavailable meeting's notes"
+      unavailable_participants: "Unavailable participants list"
     recording:
       confirm:
         destroy: "Are you sure you want to delete this recording?"

--- a/themes/rnp/config/locales/es.yml
+++ b/themes/rnp/config/locales/es.yml
@@ -52,6 +52,8 @@ es:
     meeting_data_download:
       download_notes: "Descargar notas de la reunión"
       download_participants: "Descargar lista de participantes"
+      unavailable_notes: "Notas de la reunión no disponibles"
+      unavailable_participants: "Lista de participantes no disponible"
     recording:
       confirm:
         destroy: "¿Estás seguro de que deseas eliminar esta grabación?"

--- a/themes/rnp/config/locales/pt.yml
+++ b/themes/rnp/config/locales/pt.yml
@@ -52,6 +52,8 @@ pt:
     meeting_data_download:
       download_notes: "Download das notas da reunião"
       download_participants: "Download da lista de participantes"
+      unavailable_notes: "Notas da reunião indisponíveis"
+      unavailable_participants: "Lista de participante indisponível"
     recording:
       confirm:
         destroy: "Você tem certeza que deseja deletar esta gravação?"

--- a/themes/rnp/views/shared/_meeting_data_download.html.erb
+++ b/themes/rnp/views/shared/_meeting_data_download.html.erb
@@ -5,7 +5,7 @@
   <% end %>
 <% else %>
   <%= button_to room_scheduled_meetings_path(@room), disabled: true, class: "dropdown-item rec-edit" do %>
-    <%= t('meetings.meeting_data_download.download_notes') %>
+    <%= t('meetings.meeting_data_download.unavailable_notes') %>
   <% end %>
 <% end %>
 
@@ -16,6 +16,6 @@
   <% end %>
 <% else %>
   <%= button_to room_scheduled_meetings_path(@room), disabled: true, class: "dropdown-item rec-edit" do %>
-    <%= t('meetings.meeting_data_download.download_participants') %>
+    <%= t('meetings.meeting_data_download.unavailable_participants') %>
   <% end %>
 <% end %>

--- a/themes/rnp/views/shared/_meeting_data_download.html.erb
+++ b/themes/rnp/views/shared/_meeting_data_download.html.erb
@@ -1,6 +1,6 @@
 <% if @notes_exist %>
-  <%= link_to room_scheduled_meeting_internal_download_notes_path(@room, @meeting[:meetingID], @meeting[:internalMeetingID]),
-    target: '_blank', class: "dropdown-item rec-edit" do %>
+  <%= button_to room_scheduled_meeting_internal_download_notes_path(@room, @meeting[:meetingID], @meeting[:internalMeetingID]),
+    method: :get, target: '_blank', class: "dropdown-item rec-edit" do %>
     <%= t('meetings.meeting_data_download.download_notes') %>
   <% end %>
 <% else %>
@@ -10,12 +10,12 @@
 <% end %>
 
 <% if @participants_exist %>
-  <%= link_to room_scheduled_meeting_internal_download_participants_path(@room, @meeting[:meetingID], @meeting[:internalMeetingID]),
-    target: '_blank', class: "dropdown-item rec-edit" do %>
+  <%= button_to room_scheduled_meeting_internal_download_participants_path(@room, @meeting[:meetingID], @meeting[:internalMeetingID]),
+    method: :get, target: '_blank', class: "dropdown-item rec-edit" do %>
     <%= t('meetings.meeting_data_download.download_participants') %>
   <% end %>
 <% else %>
-  <%= button_to room_scheduled_meetings_path(@room), disabled: true, class: "dropdown-item rec-edit" do %>
+  <%= button_to room_scheduled_meetings_path(@room),disabled: true,  class: "dropdown-item rec-edit" do %>
     <%= t('meetings.meeting_data_download.unavailable_participants') %>
   <% end %>
 <% end %>

--- a/themes/rnp/views/shared/_meeting_row.html.erb
+++ b/themes/rnp/views/shared/_meeting_row.html.erb
@@ -86,7 +86,7 @@
       <% if recording[:state] != 'processing' && recording[:published] || can_edit?(user, room) %>
         <div class="dropdown dropdown-opts">
           <a href="#" class="dropdown-toggle d-flex text-decoration-none dropdown-opts-link"
-            meeting-id="<%= meeting[:internalMeetingID] %>" 
+            meeting-id="<%= meeting[:meetingID] %>" 
             check-bucket-files-endpoint="<%= room_scheduled_meeting_internal_check_bucket_files_path(@room, meeting[:meetingID], meeting[:internalMeetingID]) %>"
             data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= icon_options_dots %>
@@ -138,6 +138,10 @@
 
               <%# Download notes and participants %>
               <div class="dropdown-divider"></div>
+              <div class="dropdown-item-loading">
+                <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_notes') %>
+                <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_participants') %>
+              </div>
             <% end %>
           </div>
         </div>
@@ -153,12 +157,16 @@
       <% if can_edit?(user, room) %>
         <div class="dropdown dropdown-opts">
           <a href="#" class="dropdown-toggle d-flex text-decoration-none dropdown-opts-link"
-            meeting-id="<%= meeting[:internalMeetingID] %>" 
+            meeting-id="<%= meeting[:meetingID] %>" 
             check-bucket-files-endpoint="<%= room_scheduled_meeting_internal_check_bucket_files_path(@room, meeting[:meetingID], meeting[:internalMeetingID]) %>"
             data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= icon_options_dots %>
           </a>
           <div class="dropdown-menu dropdown-menu-right dropdown-items" aria-labelledby="dropdown-opts-<%= meeting[:meetingID] %>">
+            <div class="dropdown-item-loading">
+              <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_notes') %>
+              <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_participants') %>
+            </div>
           </div>
         </div>
       <% end %>

--- a/themes/rnp/views/shared/_meeting_row.html.erb
+++ b/themes/rnp/views/shared/_meeting_row.html.erb
@@ -85,10 +85,13 @@
     <td class="col-2 col-md-1 td-dropdown-opts">
       <% if recording[:state] != 'processing' && recording[:published] || can_edit?(user, room) %>
         <div class="dropdown dropdown-opts">
-          <a href="#" class="dropdown-toggle d-flex text-decoration-none" id="dropdown-opts-<%= recording[:recordID] %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a href="#" class="dropdown-toggle d-flex text-decoration-none dropdown-opts-link"
+            meeting-id="<%= meeting[:internalMeetingID] %>" 
+            check-bucket-files-endpoint="<%= room_scheduled_meeting_internal_check_bucket_files_path(@room, meeting[:meetingID], meeting[:internalMeetingID]) %>"
+            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= icon_options_dots %>
           </a>
-          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown-opts-<%= recording[:recordID] %>">
+          <div class="dropdown-menu dropdown-menu-right dropdown-items" aria-labelledby="dropdown-opts-<%= recording[:recordID] %>">
 
             <%# Copy playback link %>
             <% if recording[:published] %>
@@ -135,10 +138,6 @@
 
               <%# Download notes and participants %>
               <div class="dropdown-divider"></div>
-              <%= render_async room_scheduled_meeting_internal_check_bucket_files_path(room, meeting[:meetingID], meeting[:internalMeetingID]) do %>
-                <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_notes') %>
-                <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_participants') %>
-              <% end %>
             <% end %>
           </div>
         </div>
@@ -153,16 +152,13 @@
     <td class="col-md-1 td-dropdown-opts">
       <% if can_edit?(user, room) %>
         <div class="dropdown dropdown-opts">
-          <a href="#" class="dropdown-toggle d-flex text-decoration-none" id="dropdown-opts-<%= meeting[:meetingID] %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a href="#" class="dropdown-toggle d-flex text-decoration-none dropdown-opts-link"
+            meeting-id="<%= meeting[:internalMeetingID] %>" 
+            check-bucket-files-endpoint="<%= room_scheduled_meeting_internal_check_bucket_files_path(@room, meeting[:meetingID], meeting[:internalMeetingID]) %>"
+            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= icon_options_dots %>
           </a>
-          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown-opts-<%= meeting[:meetingID] %>">
-
-          <%# Download notes and participants %>
-          <%= render_async room_scheduled_meeting_internal_check_bucket_files_path(room, meeting[:meetingID], meeting[:internalMeetingID]) do %>
-            <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_notes') %>
-            <%= render "shared/placeholder-loading", text: t('meetings.meeting_data_download.download_participants') %>
-          <% end %>
+          <div class="dropdown-menu dropdown-menu-right dropdown-items" aria-labelledby="dropdown-opts-<%= meeting[:meetingID] %>">
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
- Now instead of being loaded with the page, the meeting notes and participants list are loading by clicking on the meeting options dropdown
- When the files fetch returns empty, is displayed messages of unavailable files
- The download items are now of the 'button_to' type and don't generate links, so you can't access them any other way than logged in