### PR TITLE
PRT-1925: fix opening learning dashboard in a new tab

### DIFF
--- a/app/assets/javascripts/meetings.js
+++ b/app/assets/javascripts/meetings.js
@@ -301,6 +301,7 @@ let showDropdownItems = (buttons, meeting_id) => {
 
   for (let button of buttons) {
     $(button).addClass('appended-item rec-edit');
+    $(button).attr("target", "_blank");
     $(`div[aria-labelledby="dropdown-opts-${meeting_id}"]`).append(button);
   }
 };


### PR DESCRIPTION
- Add via js the `target='_blank'` attribute to the learning dashboard button