### PR TITLE
[PRT-1960] Fix: renames engagement report

### DIFF
--- a/themes/elos/config/locales/en.yml
+++ b/themes/elos/config/locales/en.yml
@@ -52,10 +52,10 @@ en:
       return: "< go back"
     load: "Load more conferences"
     meeting_data_download:
-      dashboard: "Learning dashboard"
+      dashboard: "Engagement report"
       download_notes: "Download meeting's notes"
       download_participants: "Download participants list"
-      unavailable_dashboard: "Unavailable learning dashboard"
+      unavailable_dashboard: "Unavailable engagement report"
       unavailable_notes: "Unavailable meeting's notes"
       unavailable_participants: "Unavailable participants list"
     recording:

--- a/themes/elos/config/locales/es.yml
+++ b/themes/elos/config/locales/es.yml
@@ -52,10 +52,10 @@ es:
       return: "< volver"
     load: "Cargar más conferencias"
     meeting_data_download:
-      dashboard: "Panel de aprendizaje"
+      dashboard: "Informe de participación"
       download_notes: "Descargar notas de la reunión"
       download_participants: "Descargar lista de participantes"
-      unavailable_dashboard: "Panel de aprendizaje no disponible"
+      unavailable_dashboard: "Informe de participación no disponible"
       unavailable_notes: "Notas de la reunión no disponibles"
       unavailable_participants: "Lista de participantes no disponible"
     recording:

--- a/themes/elos/config/locales/pt.yml
+++ b/themes/elos/config/locales/pt.yml
@@ -52,10 +52,10 @@ pt:
       return: "< voltar"
     load: "Carregar mais conferências"
     meeting_data_download:
-      dashboard: "Painel de aprendizagem"
+      dashboard: "Relatório de engajamento"
       download_notes: "Download das notas da reunião"
       download_participants: "Download da lista de participantes"
-      unavailable_dashboard: "Painel de aprendizagem indisponível"
+      unavailable_dashboard: "Relatório de engajamento indisponível"
       unavailable_notes: "Notas da reunião indisponíveis"
       unavailable_participants: "Lista de participante indisponível"
     recording:

--- a/themes/rnp/config/locales/en.yml
+++ b/themes/rnp/config/locales/en.yml
@@ -58,10 +58,10 @@ en:
       return: "< go back"
     load: "Load more conferences"
     meeting_data_download:
-      dashboard: "Learning dashboard"
+      dashboard: "Engagement report"
       download_notes: "Download meeting's notes"
       download_participants: "Download participants list"
-      unavailable_dashboard: "Unavailable learning dashboard"
+      unavailable_dashboard: "Unavailable engagement report"
       unavailable_notes: "Unavailable meeting's notes"
       unavailable_participants: "Unavailable participants list"
     recording:

--- a/themes/rnp/config/locales/es.yml
+++ b/themes/rnp/config/locales/es.yml
@@ -58,10 +58,10 @@ es:
       return: "< volver"
     load: "Cargar más conferencias"
     meeting_data_download:
-      dashboard: "Panel de aprendizaje"
+      dashboard: "Informe de participación"
       download_notes: "Descargar notas de la reunión"
       download_participants: "Descargar lista de participantes"
-      unavailable_dashboard: "Panel de aprendizaje no disponible"
+      unavailable_dashboard: "Informe de participación no disponible"
       unavailable_notes: "Notas de la reunión no disponibles"
       unavailable_participants: "Lista de participantes no disponible"
     recording:

--- a/themes/rnp/config/locales/pt.yml
+++ b/themes/rnp/config/locales/pt.yml
@@ -58,10 +58,10 @@ pt:
       return: "< voltar"
     load: "Carregar mais conferências"
     meeting_data_download:
-      dashboard: "Painel de aprendizagem"
+      dashboard: "Relatório de engajamento"
       download_notes: "Download das notas da reunião"
       download_participants: "Download da lista de participantes"
-      unavailable_dashboard: "Painel de aprendizagem indisponível"
+      unavailable_dashboard: "Relatório de engajamento indisponível"
       unavailable_notes: "Notas da reunião indisponíveis"
       unavailable_participants: "Lista de participante indisponível"
     recording:


### PR DESCRIPTION
Rename learning dashboard to engagement report in all languages

**PT:**
Painel de aprendizagem => Relatório de engajamento
Painel de aprendizagem indisponível => Relatório de engajamento indisponível

**EN:**
Learning dashboard => Engagement report
Unavailable learning dashboard => Unavailable engagement report

**ES:**
Panel de aprendizaje => Informe de participación
Panel de aprendizaje no disponible => Informe de participación no disponible