### PR TITLE
[PRT-574] Disable redirection of scheduled_meetings links with numeric IDs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -136,15 +136,6 @@ class ApplicationController < ActionController::Base
 
   def find_scheduled_meeting
     @scheduled_meeting = @room.scheduled_meetings.from_param(params[:id])
-    # Fail if scheduled meeting was not found
-    return if @scheduled_meeting.blank?
-
-    # Succeed if scheduled_meeting was found with friendly_id
-    return @scheduled_meeting if @scheduled_meeting.friendly_id == params[:id]
-
-    # Redirect if scheduled_meeting was found with regular id
-    redirect_to(url_for(id: @scheduled_meeting.friendly_id),
-                status: :moved_permanently)
   end
 
   def validate_scheduled_meeting

--- a/app/models/scheduled_meeting.rb
+++ b/app/models/scheduled_meeting.rb
@@ -45,10 +45,10 @@ class ScheduledMeeting < ApplicationRecord
   }
 
   def self.from_param(param)
-    # This will accept both id an hash_id
-    # If we want to accept only hash_id change it to:
-    #   friendly.find_by(hash_id: param)
-    friendly.find(param)
+    # This will accept only `hash_id`
+    # To accept both `id` an `hash_id`, change it to:
+    # friendly.find(param)
+    friendly.find_by(hash_id: param)
   rescue ActiveRecord::RecordNotFound
     nil
   end


### PR DESCRIPTION
Now a link to a `scheduled_meeting` only works with its `hash_id`.