### PR TITLE
[PRT-2185] Session tokens

### DIFF
--- a/app/controllers/scheduled_meetings_controller.rb
+++ b/app/controllers/scheduled_meetings_controller.rb
@@ -15,6 +15,7 @@ class ScheduledMeetingsController < ApplicationController
   # validate the room/session only for routes that are not open
   before_action :find_room
   before_action :validate_room, except: open_actions
+  before_action :validate_session_token_and_restore_session, only: :join
   before_action :find_user
   before_action :find_app_launch, only: %i[create update destroy]
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
         data-controller="<%= params[:controller] %>"
         data-action="<%= params[:action] %>"
         data-use-cable="<%= Rails.configuration.cable_enabled %>"
+        data-session-token-url="<%= create_session_token_url %>"
         class="<%= theme_class %>">
     <%= render 'layouts/gtm_body' if app_theme == 'elos' %>
     <div class="container">

--- a/app/views/shared/_toast.html.erb
+++ b/app/views/shared/_toast.html.erb
@@ -1,0 +1,10 @@
+<%# expected partial variables: [toast_id, text] %>
+
+<div id="<%= toast_id %>" aria-live="polite" aria-atomic="true" class="d-flex justify-content-center align-items-center toast-area">
+  <div class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="40000">
+    <div class="toast-header">
+      <%= text %>
+      <button type="button" class="ms-2 my-1 btn-close" data-bs-dismiss="toast"></button>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -285,6 +285,7 @@ en:
         suggestion: "Invalid session token"
         explanation: "The provided session token is not valid. Please try accessing the link again."
         status_code: "401"
+      request_failed: "Failed to create the session token. Please reload the page"
     meeting:
       learning_dashboard_url_missing: "Error: Learning dashboard URL not configured"
   bucket_api:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,6 +279,12 @@ en:
         suggestion:    "The scheduled meeting was not found"
         explanation: "It might have been removed by the session creator."
         status_code: "404"
+    session_token:
+      token_not_found:
+        message: "Unauthorized"
+        suggestion: "Invalid session token"
+        explanation: "The provided session token is not valid. Please try accessing the link again."
+        status_code: "401"
     meeting:
       learning_dashboard_url_missing: "Error: Learning dashboard URL not configured"
   bucket_api:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -252,6 +252,7 @@ es:
         suggestion: "Token de sesión inválido"
         explanation: "El token de sesión proporcionado no es válido. Intente acceder al enlace nuevamente."
         status_code: "401"
+      request_failed: "No se ha podido crear el token de sesión. Vuelva a cargar la página"
     meeting:
       learning_dashboard_url_missing: "Error: URL del panel de aprendizaje no está configurada"
   bucket_api:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -246,6 +246,12 @@ es:
         suggestion:  "No se encontró la programación"
         explanation: "Es posible que el creador de la sesión lo haya eliminado."
         status_code: "404"
+    session_token:
+      token_not_found:
+        message: "No autorizado"
+        suggestion: "Token de sesión inválido"
+        explanation: "El token de sesión proporcionado no es válido. Intente acceder al enlace nuevamente."
+        status_code: "401"
     meeting:
       learning_dashboard_url_missing: "Error: URL del panel de aprendizaje no está configurada"
   bucket_api:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -246,6 +246,12 @@ pt:
         suggestion: "O agendamento não foi encontrado."
         explanation: "Ele pode ter sido removido pelo criador da sessão."
         status_code: "404"
+    session_token:
+      token_not_found:
+        message: "Não autorizado"
+        suggestion: "Token de sessão inválido"
+        explanation: "O token de sessão informado não é válido. Tente acessar o link novamente."
+        status_code: "401"
     meeting:
       learning_dashboard_url_missing: "Erro: URL do painel de aprendizagem não configurada"
   bucket_api:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -252,6 +252,7 @@ pt:
         suggestion: "Token de sessão inválido"
         explanation: "O token de sessão informado não é válido. Tente acessar o link novamente."
         status_code: "401"
+      request_failed: "Falha na criação do token de sessão. Por favor recarregue a página"
     meeting:
       learning_dashboard_url_missing: "Erro: URL do painel de aprendizagem não configurada"
   bucket_api:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
         # Handles sessions.
         get '/sessions/create'
         get '/sessions/failure'
+        get '/sessions/create_session_token', as: :create_session_token
 
         # Handles Omniauth authentication.
         post '/auth/:provider', to: 'sessions#new', as: :omniauth_authorize

--- a/themes/elos/assets/javascripts/theme-application-elos.js
+++ b/themes/elos/assets/javascripts/theme-application-elos.js
@@ -62,6 +62,39 @@ $(document).on('turbolinks:load', function(){
     return true;
   });
 
+  // Links that open in a new tab need a session token to access the
+  // user session in an external context, where the Rails cookie cannot be used.
+  // Makes an AJAX request to obtain a session token, and then opens a new window
+  // with the URL that includes the session token as a query parameter
+  $(".create-session-token").on('click.sessionToken', function(e) {
+    e.preventDefault();
+
+    let url;
+    try {
+      url = new URL($(this).attr('href'));
+    } catch (error) {
+      console.error('Invalid URL:', error);
+      return;
+    }
+    const sessionTokenUrl = $('body').data('session-token-url');
+    // e.g. ['', 'rooms', '883a883477bd260c46d7d87a1553204f1d7a620c']
+    const roomId = window.location.pathname.split('/')[2];
+    if (!sessionTokenUrl || !roomId) {
+      console.error('Missing required data attributes for create-session-token AJAX call.');
+      return;
+    }
+
+    const params = { room_id: roomId };
+    $.getJSON(sessionTokenUrl, params)
+      .done(function(data) {
+        url.searchParams.set('session_token', data.token);
+        window.open(url);
+      })
+      .fail(function(jqXHR) {
+        console.warn('Request to create session_token failed:', jqXHR.responseText);
+      });
+  });
+
   // When the #meetings-filters radio input changes, adds or removes a class to
   // #meetings-table, which will hide or show meetings depending on the filter.
   // Also adds the filter to the current URL, so it can be kept between page reloads.

--- a/themes/elos/assets/javascripts/theme-application-elos.js
+++ b/themes/elos/assets/javascripts/theme-application-elos.js
@@ -91,6 +91,9 @@ $(document).on('turbolinks:load', function(){
         window.open(url);
       })
       .fail(function(jqXHR) {
+        $toast = $('.toast', '#session-token-req-failed-toast');
+        $toast.toast('dispose');
+        $toast.toast('show');
         console.warn('Request to create session_token failed:', jqXHR.responseText);
       });
   });

--- a/themes/elos/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/elos/views/shared/_scheduled_meeting_row.html.erb
@@ -21,7 +21,7 @@
   </td>
   <td class="col-12 col-md-1 align-middle">
     <%=
-      link_to join_room_scheduled_meeting_path(room, meeting), class: "btn btn-primary join-room-btn", target: '_blank' do
+      link_to join_room_scheduled_meeting_url(room, meeting), class: "btn btn-primary join-room-btn create-session-token", target: '_blank' do
     %>
       <i class="icon material-icons">play_arrow</i>
     <% end %>

--- a/themes/elos/views/shared/_scheduled_meetings.html.erb
+++ b/themes/elos/views/shared/_scheduled_meetings.html.erb
@@ -73,11 +73,4 @@
   <%= render "shared/external_widget" %>
 <% end %>
 
-<div id="external-link-copied-toast" aria-live="polite" aria-atomic="true" class="d-flex justify-content-center align-items-center toast-area">
-  <div class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="40000">
-    <div class="toast-header">
-      <%= t('_all.clipboard.link_copied') %>
-      <button type="button" class="ms-2 my-1 btn-close" data-bs-dismiss="toast"></button>
-    </div>
-  </div>
-</div>
+<%= render "shared/toast", {toast_id: 'external-link-copied-toast', text: t('_all.clipboard.link_copied')} %>

--- a/themes/elos/views/shared/_scheduled_meetings.html.erb
+++ b/themes/elos/views/shared/_scheduled_meetings.html.erb
@@ -74,3 +74,4 @@
 <% end %>
 
 <%= render "shared/toast", {toast_id: 'external-link-copied-toast', text: t('_all.clipboard.link_copied')} %>
+<%= render "shared/toast", {toast_id: 'session-token-req-failed-toast', text: t('error.session_token.request_failed')} %>

--- a/themes/rnp/assets/javascripts/theme-application-rnp.js
+++ b/themes/rnp/assets/javascripts/theme-application-rnp.js
@@ -63,6 +63,39 @@ $(document).on('turbolinks:load', function(){
     return true;
   });
 
+  // Links that open in a new tab need a session token to access the
+  // user session in an external context, where the Rails cookie cannot be used.
+  // Makes an AJAX request to obtain a session token, and then opens a new window
+  // with the URL that includes the session token as a query parameter
+  $(".create-session-token").on('click.sessionToken', function(e) {
+    e.preventDefault();
+
+    let url;
+    try {
+      url = new URL($(this).attr('href'));
+    } catch (error) {
+      console.error('Invalid URL:', error);
+      return;
+    }
+    const sessionTokenUrl = $('body').data('session-token-url');
+    // e.g. ['', 'rooms', '883a883477bd260c46d7d87a1553204f1d7a620c']
+    const roomId = window.location.pathname.split('/')[2];
+    if (!sessionTokenUrl || !roomId) {
+      console.error('Missing required data attributes for create-session-token AJAX call.');
+      return;
+    }
+
+    const params = { room_id: roomId };
+    $.getJSON(sessionTokenUrl, params)
+      .done(function(data) {
+        url.searchParams.set('session_token', data.token);
+        window.open(url);
+      })
+      .fail(function(jqXHR) {
+        console.warn('Request to create session_token failed:', jqXHR.responseText);
+      });
+  });
+
   // When the #meetings-filters radio input changes, adds or removes a class to
   // #meetings-table, which will hide or show meetings depending on the filter.
   // Also adds the filter to the current URL, so it can be kept between page reloads.

--- a/themes/rnp/assets/javascripts/theme-application-rnp.js
+++ b/themes/rnp/assets/javascripts/theme-application-rnp.js
@@ -92,6 +92,9 @@ $(document).on('turbolinks:load', function(){
         window.open(url);
       })
       .fail(function(jqXHR) {
+        $toast = $('.toast', '#session-token-req-failed-toast');
+        $toast.toast('dispose');
+        $toast.toast('show');
         console.warn('Request to create session_token failed:', jqXHR.responseText);
       });
   });

--- a/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
@@ -30,7 +30,7 @@
       <% end %>
     <% else %>
       <%=
-        link_to join_room_scheduled_meeting_path(room, meeting, no_auto_join: true), class: "btn btn-primary join-room-btn", target: '_blank' do
+        link_to join_room_scheduled_meeting_url(room, meeting, no_auto_join: true), class: "btn btn-primary join-room-btn create-session-token", target: '_blank' do
       %>
         <i class="icon material-icons">play_arrow</i>
       <% end %>

--- a/themes/rnp/views/shared/_scheduled_meetings.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meetings.html.erb
@@ -71,11 +71,4 @@
   <%= image_tag "site_logo_conferencia_web_pq_azul.png", title: "RNP", class: "mx-auto" %>
 </div>
 
-<div id="external-link-copied-toast" aria-live="polite" aria-atomic="true" class="d-flex justify-content-center align-items-center toast-area">
-  <div class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="40000">
-    <div class="toast-header">
-      <%= t('_all.clipboard.link_copied') %>
-      <button type="button" class="ms-2 my-1 btn-close" data-bs-dismiss="toast"></button>
-    </div>
-  </div>
-</div>
+<%= render "shared/toast", {toast_id: 'external-link-copied-toast', text: t('_all.clipboard.link_copied')} %>

--- a/themes/rnp/views/shared/_scheduled_meetings.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meetings.html.erb
@@ -72,3 +72,4 @@
 </div>
 
 <%= render "shared/toast", {toast_id: 'external-link-copied-toast', text: t('_all.clipboard.link_copied')} %>
+<%= render "shared/toast", {toast_id: 'session-token-req-failed-toast', text: t('error.session_token.request_failed')} %>


### PR DESCRIPTION
A **session token** is a short-lived nonce associated with a specific user session, which can be used to retrieve that session when the application is opened in a external context, such as a new tab, where the original cookie can no longer be accessed.

Changes:
- Route and action to create a session token. A key-pair is stored in the cache (with 2 minutes expiration), associating the session token, a 16-long SecureRandom hex string, to the current `app_launch`. Returns a JSON with the token
- `before_action` to check for and validate a session token, and restore the associated session
- Javascript code to obtain a session token and append it to links that open in a new tab. The link must have the class `create-session-token`
- Retrieve the session on `scheduled_meetings#join` action