### PR TITLE
[PRT-2183] Fix meeting data access on new tab

### DIFF
--- a/app/assets/javascripts/meetings.js
+++ b/app/assets/javascripts/meetings.js
@@ -299,8 +299,9 @@ let showDropdownItems = (buttons, meeting_id) => {
   // Remove only the items appended previously
   $(`div[aria-labelledby="dropdown-opts-${meeting_id}"] .appended-item`).remove();
 
+  // these buttons open in a new tab, so they must include a session token
   for (let button of buttons) {
-    $(button).addClass('appended-item rec-edit');
+    $(button).addClass('appended-item rec-edit create-session-token');
     $(button).attr("target", "_blank");
     $(`div[aria-labelledby="dropdown-opts-${meeting_id}"]`).append(button);
   }

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -8,6 +8,7 @@ class MeetingsController < ApplicationController
 
   before_action :find_room
   before_action :get_scheduled_meeting_info
+  before_action :validate_session_token_and_restore_session, only: [:download_notes, :download_participants, :learning_dashboard]
   before_action :find_user, only: [:check_bucket_files, :download_notes, :download_participants, :learning_dashboard]
   before_action :check_bucket_credentials, only: [:download_notes, :download_participants, :learning_dashboard]
   before_action :check_bucket_access_data, only: [:download_notes, :download_participants, :learning_dashboard]

--- a/app/helpers/meetings_helper.rb
+++ b/app/helpers/meetings_helper.rb
@@ -15,11 +15,21 @@ module MeetingsHelper
     meeting[:room] = room
     if self.bucket_configured? && self.has_required_info_for_bucket?(meeting)
       file = self.filename_for_datafile(file_type)
-      return false if file.nil?
+      if file.nil?
+        Rails.logger.warn "[meetings_helper] Invalid file type '#{file_type}'"
+        return false
+      end
 
       key = Mconf::BucketApi.gen_key(meeting, file)
+
+      Rails.logger.info "[meetings_helper] meeting=#{meeting.except(:room)}, " \
+      "room_handler=#{room&.handler}, key=#{key}"
+
       Mconf::BucketApi.file_exists?(meeting, key)
     else
+      Rails.logger.warn '[meetings_helper] The bucket is configured but some ' \
+      'required info is missing' if self.bucket_configured?
+
       false
     end
   end

--- a/themes/elos/assets/javascripts/theme-application-elos.js
+++ b/themes/elos/assets/javascripts/theme-application-elos.js
@@ -65,13 +65,20 @@ $(document).on('turbolinks:load', function(){
   // Links that open in a new tab need a session token to access the
   // user session in an external context, where the Rails cookie cannot be used.
   // Makes an AJAX request to obtain a session token, and then opens a new window
-  // with the URL that includes the session token as a query parameter
-  $(".create-session-token").on('click.sessionToken', function(e) {
+  // with the URL that includes the session token as a query parameter.
+  // Delegates the event listener to body and check if the click target has the expected class,
+  // to listen even for dinamically created elements
+  $('body').on('click', '.create-session-token', function(e) {
     e.preventDefault();
 
+    const elem = $(this);
     let url;
     try {
-      url = new URL($(this).attr('href'));
+      if (elem.is('a')) {
+        url = new URL(elem.attr('href'), window.location.origin);
+      } else if (elem.is('form')) {
+        url = new URL(elem.attr('action'), window.location.origin);
+      }
     } catch (error) {
       console.error('Invalid URL:', error);
       return;

--- a/themes/elos/views/errors/index.html.erb
+++ b/themes/elos/views/errors/index.html.erb
@@ -1,4 +1,5 @@
 <%= render 'errors/error',
+    internal_key: @error[:internal_key],
     code: @error[:code],
     message: @error[:message],
     suggestion: @error[:suggestion],

--- a/themes/rnp/assets/javascripts/theme-application-rnp.js
+++ b/themes/rnp/assets/javascripts/theme-application-rnp.js
@@ -66,13 +66,20 @@ $(document).on('turbolinks:load', function(){
   // Links that open in a new tab need a session token to access the
   // user session in an external context, where the Rails cookie cannot be used.
   // Makes an AJAX request to obtain a session token, and then opens a new window
-  // with the URL that includes the session token as a query parameter
-  $(".create-session-token").on('click.sessionToken', function(e) {
+  // with the URL that includes the session token as a query parameter.
+  // Delegates the event listener to body and check if the click target has the expected class,
+  // to listen even for dinamically created elements
+  $('body').on('click', '.create-session-token', function(e) {
     e.preventDefault();
 
+    const elem = $(this);
     let url;
     try {
-      url = new URL($(this).attr('href'));
+      if (elem.is('a')) {
+        url = new URL(elem.attr('href'), window.location.origin);
+      } else if (elem.is('form')) {
+        url = new URL(elem.attr('action'), window.location.origin);
+      }
     } catch (error) {
       console.error('Invalid URL:', error);
       return;

--- a/themes/rnp/views/errors/index.html.erb
+++ b/themes/rnp/views/errors/index.html.erb
@@ -1,4 +1,5 @@
 <%= render 'errors/error',
+    internal_key: @error[:internal_key],
     code: @error[:code],
     message: @error[:message],
     suggestion: @error[:suggestion],


### PR DESCRIPTION
The meeting data links open in a new tab, so a session token is needed to restore the session and authorize the user in that new tab.