### PR TITLE
[PRT-2290] Fix for app_offcanvas opening the wrong meeting 

### DIFF
--- a/app/assets/javascripts/rooms.js
+++ b/app/assets/javascripts/rooms.js
@@ -32,7 +32,7 @@ $(document).on('turbolinks:load', function(){
       success: function(data) {
         if (data['running'] === true) {
           if (data['can_join_or_create'] === true && isMobile()) {
-            $("#offcanvasBottom").offcanvas('show');
+            $(".offcanvas-bottom").offcanvas('show');
           } else {
             joinSession();
           }
@@ -152,7 +152,7 @@ $(document).on('turbolinks:load', function(){
       let canJoin = $('#wait-for-moderator').data('can-join');
       if (canJoin === true && isMobile()){
         setTimeout(function() {
-          $("#offcanvasBottom").offcanvas('show');
+          $(".offcanvas-bottom").offcanvas('show');
         }, 200);
       } else {
         setTimeout(function() { joinSession(); }, 200);

--- a/themes/rnp/views/scheduled_meetings/external.html.erb
+++ b/themes/rnp/views/scheduled_meetings/external.html.erb
@@ -67,7 +67,7 @@
                 <%= link_to t('default.scheduled_meeting.external.guest_name_change'), guest_logout_room_scheduled_meeting_path, class: "btn-secondary" %>
               </div>
             <% end %>
-            <button class="btn btn-primary" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasBottom" aria-controls="offcanvasBottom">
+            <button class="btn btn-primary" type="button" data-bs-toggle="offcanvas" data-bs-target=<%="#offcanvasBottom-#{@scheduled_meeting.hash_id}"%> aria-controls="offcanvasBottom">
               <%= t('default.scheduled_meeting.external.join') %>
             </button>
           </div>

--- a/themes/rnp/views/scheduled_meetings/wait.html.erb
+++ b/themes/rnp/views/scheduled_meetings/wait.html.erb
@@ -35,10 +35,10 @@
 
     <%= form_with url: @post_to, id: 'join-form' do |form| %>
       <div id="open-modal" class="" >
-        <button id="open-app-modal" class="d-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasBottom" aria-controls="offcanvasBottom">
+        <button id="open-app-modal" class="d-none" type="button" data-bs-toggle="offcanvas" data-bs-target=<%="#offcanvasBottom-#{@scheduled_meeting.hash_id}"%> aria-controls="offcanvasBottom">
           <%= t('scheduled_meetings.wait.retry') %>
         </button>
-        <%= render "shared/app_offcanvas", submit: true %>
+        <%= render "shared/app_offcanvas", submit: true, room: @room, meeting: @scheduled_meeting %>
       </div>
     <% end %>
     <div id="wait-for-moderator-back" style="display: none;">

--- a/themes/rnp/views/shared/_app_offcanvas.html.erb
+++ b/themes/rnp/views/shared/_app_offcanvas.html.erb
@@ -4,7 +4,7 @@
 <% target_blank ||= false %>
 
 
-<div class="offcanvas offcanvas-bottom" tabindex="-1" id="offcanvasBottom" aria-labelledby="offcanvasBottomLabel">
+<div class="offcanvas offcanvas-bottom" tabindex="-1" id=<%="offcanvasBottom-#{meeting.hash_id}"%> aria-labelledby="offcanvasBottomLabel">
   <div id="rnp-logo" class="d-flex align-items-center">
     <%= image_tag "conferenciaweb_logo.svg", title: "RNP", class: "mx-auto" %>
   </div>

--- a/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
@@ -23,7 +23,7 @@
     <% can_join = !(wait_for_mod?(meeting, user)) %>
     <% if can_join && device_type? != 'desktop' %>
       <%= form_with url: join_room_scheduled_meeting_path(room, meeting), id: 'join-form' do |form| %>
-        <button class="btn btn-primary join-room-btn" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasBottom" aria-controls="offcanvasBottom">
+        <button class="btn btn-primary join-room-btn" type="button" data-bs-toggle="offcanvas" data-bs-target=<%="#offcanvasBottom-#{meeting.hash_id}"%> aria-controls="offcanvasBottom">
           <i class="icon material-icons">play_arrow</i>
         </button>
         <%= render "shared/app_offcanvas", room: room, meeting: meeting, target_blank: !(browser.safari? || browser.safari_webapp_mode?) %>


### PR DESCRIPTION
- If there was more than one `scheduled_meeting` in the `rooms#show` list, clicking the join button of any meeting after the first would open the wrong offcanvas, because they all had the same id (`offcanvasBottom`)
- Now we use the meeting's `hash_id` to identify each offcanvas
- Only affects the RNP theme