### PR TITLE
[PRT-2356] Remove deprecated `mconf_custom_logout_url` join meeting userdata

### DIFF
--- a/lib/bbb_api.rb
+++ b/lib/bbb_api.rb
@@ -77,7 +77,6 @@ module BbbApi
         room.attributes[role],
         {
           'userdata-bbb_override_default_locale': locale,
-          'userdata-mconf_custom_logout_url': logout_url,
           'userdata-bbb_feedback_redirect_url': logout_url,
           userID: user.uid,
           redirect: false
@@ -101,7 +100,6 @@ module BbbApi
       room.attributes[role],
       {
         'userdata-bbb_override_default_locale': locale,
-        'userdata-mconf_custom_logout_url': logout_url,
         'userdata-bbb_feedback_redirect_url': logout_url,
         userID: user.uid
       }
@@ -123,7 +121,6 @@ module BbbApi
       room.attributes['viewer'],
       { guest: true,
         'userdata-bbb_override_default_locale': locale,
-        'userdata-mconf_custom_logout_url': logout_url,
         'userdata-bbb_feedback_redirect_url': logout_url,
         userID: uid
       }


### PR DESCRIPTION
Now only `bbb_feedback_redirect_url` is used