### PR TITLE
[PRT-2582] Allow students create meetings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -169,7 +169,7 @@ class ApplicationController < ActionController::Base
   end
 
   def find_scheduled_meeting
-    @scheduled_meeting = @room.scheduled_meetings.from_param(params[:id])
+    @scheduled_meeting = @room.scheduled_meetings.includes(:creator_launch).from_param(params[:id])
   end
 
   def validate_scheduled_meeting

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -424,7 +424,8 @@ class RoomsController < ApplicationController
       external_widget: custom_params['external_widget'],
       external_disclaimer: custom_params['external_disclaimer'],
       external_context_url: custom_params['external_context_url'],
-      institution_guid: custom_params['institution_guid']
+      institution_guid: custom_params['institution_guid'],
+      allow_student_scheduling: custom_params['allow_student_scheduling']
     )
     Rails.logger.info "[setup_consumer_configs] ConsumerConfig created/updated with key=#{@consumer_config.key}, " \
     "params=#{custom_params.except('bbb', 'moodle', 'brightspace')}"

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -40,7 +40,7 @@ class RoomsController < ApplicationController
   def show
     respond_to do |format|
       @room.update_recurring_meetings
-      @scheduled_meetings = @room.scheduled_meetings.active
+      @scheduled_meetings = @room.scheduled_meetings.active.includes(:creator_launch)
 
       if @room.moodle_group_select_enabled?
         @scheduled_meetings = @scheduled_meetings.where(moodle_group_id: Rails.cache.read("#{@app_launch.nonce}/current_group_id"))

--- a/app/controllers/scheduled_meetings_controller.rb
+++ b/app/controllers/scheduled_meetings_controller.rb
@@ -27,8 +27,11 @@ class ScheduledMeetingsController < ApplicationController
   before_action only: %i[join external wait] do
     authorize_user!(:show, @scheduled_meeting) if @user.present?
   end
-  before_action only: %i[new create edit update destroy] do
-    authorize_user!(:edit, @room)
+  before_action only: %i[new create] do
+    authorize_user!(:create_scheduled_meeting, @room)
+  end
+  before_action only: %i[edit update destroy] do
+    authorize_user!(:manage_scheduled_meeting, @scheduled_meeting)
   end
 
   before_action :set_blank_repeat_as_nil, only: %i[create update]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,6 +39,14 @@ module ApplicationHelper
     Abilities.can?(user, :download_presentation_video, resource)
   end
 
+  def can_create_scheduled_meeting?(user, room)
+    Abilities.can?(user, :create_scheduled_meeting, room)
+  end
+
+  def can_manage_scheduled_meeting?(user, meeting)
+    Abilities.can?(user, :manage_scheduled_meeting, meeting)
+  end
+
   def show_terms_use_message?(resource)
     config = ConsumerConfig.find_by(key: resource[:consumer_key])
     config.present? && config[:message_reference_terms_use]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,6 +47,10 @@ module ApplicationHelper
     Abilities.can?(user, :manage_scheduled_meeting, meeting)
   end
 
+  def allow_student_scheduling?(room)
+    Abilities.allow_student_scheduling?(room)
+  end
+
   def show_terms_use_message?(resource)
     config = ConsumerConfig.find_by(key: resource[:consumer_key])
     config.present? && config[:message_reference_terms_use]

--- a/app/models/abilities.rb
+++ b/app/models/abilities.rb
@@ -1,5 +1,7 @@
 class Abilities
 
+  ALLOW_STUDENT_SCHEDULING_CACHE_KEY = :abilities_allow_student_scheduling_cache
+
   # This is a simplified authorization mechanism
   # TODO: verifiy the resource as well
   def self.can?(user, action, resource)
@@ -42,8 +44,15 @@ class Abilities
   def self.allow_student_scheduling?(resource)
     return false if resource.blank?
 
-    config = ConsumerConfig.select(:allow_student_scheduling).find_by(key: resource.consumer_key)
-    config.present? && config.allow_student_scheduling?
+    consumer_key = resource.consumer_key
+    return false if consumer_key.blank?
+
+    # Keep this cache to avoid repeated queries during a single render
+    cache = ActiveSupport::IsolatedExecutionState[ALLOW_STUDENT_SCHEDULING_CACHE_KEY] ||= {}
+    return cache[consumer_key] if cache.key?(consumer_key)
+
+    config = ConsumerConfig.select(:allow_student_scheduling).find_by(key: consumer_key)
+    cache[consumer_key] = config.present? && config.allow_student_scheduling?
   end
 
   def self.user_created_meeting?(user, resource)

--- a/app/models/abilities.rb
+++ b/app/models/abilities.rb
@@ -1,7 +1,6 @@
 class Abilities
 
-  # This is a simplified authorization mechanism that has three actions:
-  # :show, :edit and :admin
+  # This is a simplified authorization mechanism
   # TODO: verifiy the resource as well
   def self.can?(user, action, resource)
     case action
@@ -23,6 +22,10 @@ class Abilities
       end
     when :download_artifacts
       user.present? && self.full_permission?(user)
+    when :create_scheduled_meeting
+      user.present? && (self.full_permission?(user) || self.allow_student_scheduling?(resource))
+    when :manage_scheduled_meeting
+      user.present? && (self.full_permission?(user) || self.user_created_meeting?(user, resource))
     else
       false
     end
@@ -34,5 +37,29 @@ class Abilities
 
   def self.moderator_roles
     Rails.configuration.bigbluebutton_moderator_roles.split(',')
+  end
+
+  def self.allow_student_scheduling?(resource)
+    return false if resource.blank?
+
+    config = ConsumerConfig.select(:allow_student_scheduling).find_by(key: resource.consumer_key)
+    config.present? && config.allow_student_scheduling?
+  end
+
+  def self.user_created_meeting?(user, resource)
+    return false if resource.blank? || user.blank?
+
+    nonce = resource.created_by_launch_nonce
+    return false if nonce.blank?
+
+    app_launch = if resource.association(:creator_launch).loaded?
+                   resource.creator_launch
+                 else
+                   AppLaunch.select(:params).find_by(nonce: nonce)
+                 end
+    return false if app_launch.blank?
+
+    creator_uid = app_launch.params&.[]('user_id')
+    creator_uid.present? && creator_uid == user.uid
   end
 end

--- a/app/models/abilities.rb
+++ b/app/models/abilities.rb
@@ -25,7 +25,7 @@ class Abilities
     when :create_scheduled_meeting
       user.present? && (self.full_permission?(user) || self.allow_student_scheduling?(resource))
     when :manage_scheduled_meeting
-      user.present? && (self.full_permission?(user) || self.user_created_meeting?(user, resource))
+      user.present? && (self.full_permission?(user) || (self.allow_student_scheduling?(resource) && self.user_created_meeting?(user, resource)))
     else
       false
     end
@@ -42,7 +42,11 @@ class Abilities
   def self.allow_student_scheduling?(resource)
     return false if resource.blank?
 
-    config = ConsumerConfig.select(:allow_student_scheduling).find_by(key: resource.consumer_key)
+    # Handle both Room and ScheduledMeeting resources
+    consumer_key = resource.is_a?(ScheduledMeeting) ? resource.room&.consumer_key : resource.consumer_key
+    return false if consumer_key.blank?
+
+    config = ConsumerConfig.select(:allow_student_scheduling).find_by(key: consumer_key)
     config.present? && config.allow_student_scheduling?
   end
 

--- a/app/models/abilities.rb
+++ b/app/models/abilities.rb
@@ -1,7 +1,5 @@
 class Abilities
 
-  ALLOW_STUDENT_SCHEDULING_CACHE_KEY = :abilities_allow_student_scheduling_cache
-
   # This is a simplified authorization mechanism
   # TODO: verifiy the resource as well
   def self.can?(user, action, resource)
@@ -44,15 +42,8 @@ class Abilities
   def self.allow_student_scheduling?(resource)
     return false if resource.blank?
 
-    consumer_key = resource.consumer_key
-    return false if consumer_key.blank?
-
-    # Keep this cache to avoid repeated queries during a single render
-    cache = ActiveSupport::IsolatedExecutionState[ALLOW_STUDENT_SCHEDULING_CACHE_KEY] ||= {}
-    return cache[consumer_key] if cache.key?(consumer_key)
-
-    config = ConsumerConfig.select(:allow_student_scheduling).find_by(key: consumer_key)
-    cache[consumer_key] = config.present? && config.allow_student_scheduling?
+    config = ConsumerConfig.select(:allow_student_scheduling).find_by(key: resource.consumer_key)
+    config.present? && config.allow_student_scheduling?
   end
 
   def self.user_created_meeting?(user, resource)

--- a/app/models/scheduled_meeting.rb
+++ b/app/models/scheduled_meeting.rb
@@ -9,6 +9,7 @@ class ScheduledMeeting < ApplicationRecord
   }.stringify_keys.freeze
 
   belongs_to :room
+  belongs_to :creator_launch, class_name: 'AppLaunch', primary_key: 'nonce', foreign_key: 'created_by_launch_nonce', optional: true
   has_one :brightspace_calendar_event,
           primary_key: :hash_id,
           foreign_key: :scheduled_meeting_hash_id,
@@ -273,6 +274,10 @@ class ScheduledMeeting < ApplicationRecord
 
   def self.default_duration_for_helper
     return 60 * 60 # 1h
+  end
+
+  def creator_name
+    @creator_name ||= creator_launch&.params&.[]('lis_person_name_full')
   end
 
   private

--- a/db/migrate/20260223182237_add_allow_student_scheduling_to_consumer_configs.rb
+++ b/db/migrate/20260223182237_add_allow_student_scheduling_to_consumer_configs.rb
@@ -1,0 +1,5 @@
+class AddAllowStudentSchedulingToConsumerConfigs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :consumer_configs, :allow_student_scheduling, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_16_103515) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_23_182237) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -71,6 +71,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_16_103515) do
     t.boolean "force_disable_external_link", default: false
     t.string "external_context_url"
     t.string "institution_guid"
+    t.boolean "allow_student_scheduling", default: false, null: false
     t.index ["key"], name: "index_consumer_configs_on_key", unique: true
   end
 
@@ -159,7 +160,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_16_103515) do
     t.integer "moodle_group_id"
     t.string "moodle_group_name"
     t.boolean "mark_moodle_attendance"
-    t.boolean "mark_brightspace_attendance"
+    t.boolean "mark_brightspace_attendance", default: false, null: false
     t.index ["created_by_launch_nonce"], name: "index_scheduled_meetings_on_created_by_launch_nonce"
     t.index ["hash_id"], name: "index_scheduled_meetings_on_hash_id", unique: true
     t.index ["repeat"], name: "index_scheduled_meetings_on_repeat"

--- a/spec/models/abilities_spec.rb
+++ b/spec/models/abilities_spec.rb
@@ -1,4 +1,110 @@
 require 'rails_helper'
 
 RSpec.describe Abilities, type: :model do
+	describe '.can?' do
+		describe 'create scheduled meeting' do
+			it 'allows users with full permission' do
+				room = Room.create!(consumer_key: 'consumer-1')
+				user = User.new(uid: 'teacher-1', roles: 'Admin', launch_nonce: 'nonce-teacher')
+
+				expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(true)
+			end
+
+			it 'allows regular users when allow_student_scheduling is enabled' do
+				ConsumerConfig.create!(key: 'consumer-2', allow_student_scheduling: true)
+				room = Room.create!(consumer_key: 'consumer-2')
+				user = User.new(uid: 'student-1', roles: 'Student', launch_nonce: 'nonce-student')
+
+				expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(true)
+			end
+
+			it 'denies regular users when allow_student_scheduling is disabled' do
+				ConsumerConfig.create!(key: 'consumer-3', allow_student_scheduling: false)
+				room = Room.create!(consumer_key: 'consumer-3')
+				user = User.new(uid: 'student-2', roles: 'Student', launch_nonce: 'nonce-student-2')
+
+				expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(false)
+			end
+		end
+
+		describe 'manage scheduled meeting' do
+			it 'allows users with full permission' do
+				room = Room.create!(consumer_key: 'consumer-4')
+				meeting = ScheduledMeeting.create!(
+					room: room,
+					name: 'Weekly class',
+					start_at: Time.zone.now + 1.hour,
+					duration: 1800,
+					created_by_launch_nonce: 'nonce-creator'
+				)
+				user = User.new(uid: 'teacher-2', roles: 'Admin', launch_nonce: 'nonce-other')
+
+				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(true)
+			end
+
+			it 'allows the creator via app launch nonce' do
+				room = Room.create!(consumer_key: 'consumer-5')
+				AppLaunch.create!(
+					nonce: 'nonce-student-creator',
+					params: {
+						'user_id' => 'student-3',
+						'context_id' => 'context-5',
+						'tool_consumer_instance_guid' => 'consumer-5',
+						'resource_link_id' => 'resource-5',
+						'custom_params' => { 'custom_enable_groups_scoping' => 'false' }
+					},
+					expires_at: Time.zone.now + 1.hour
+				)
+				meeting = ScheduledMeeting.create!(
+					room: room,
+					name: 'Office hours',
+					start_at: Time.zone.now + 1.hour,
+					duration: 1800,
+					created_by_launch_nonce: 'nonce-student-creator'
+				)
+				user = User.new(uid: 'student-3', roles: 'Student', launch_nonce: 'nonce-student-creator')
+
+				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(true)
+			end
+
+			it 'denies non-creator students' do
+				room = Room.create!(consumer_key: 'consumer-7')
+				AppLaunch.create!(
+					nonce: 'nonce-owner',
+					params: {
+						'user_id' => 'student-owner',
+						'context_id' => 'context-7',
+						'tool_consumer_instance_guid' => 'consumer-7',
+						'resource_link_id' => 'resource-7',
+						'custom_params' => { 'custom_enable_groups_scoping' => 'false' }
+					},
+					expires_at: Time.zone.now + 1.hour
+				)
+				meeting = ScheduledMeeting.create!(
+					room: room,
+					name: 'Lab',
+					start_at: Time.zone.now + 1.hour,
+					duration: 1800,
+					created_by_launch_nonce: 'nonce-owner'
+				)
+				user = User.new(uid: 'student-other', roles: 'Student', launch_nonce: 'nonce-other')
+
+				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
+			end
+
+			it 'denies access when app launch is missing (expired/deleted)' do
+				room = Room.create!(consumer_key: 'consumer-8')
+				meeting = ScheduledMeeting.create!(
+					room: room,
+					name: 'Old meeting',
+					start_at: Time.zone.now + 1.hour,
+					duration: 1800,
+					created_by_launch_nonce: 'nonce-expired'
+				)
+				user = User.new(uid: 'student-4', roles: 'Student', launch_nonce: 'nonce-student-4')
+
+				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
+			end
+		end
+	end
 end

--- a/spec/models/abilities_spec.rb
+++ b/spec/models/abilities_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe Abilities, type: :model do
         expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(true)
       end
 
-      it 'allows the creator via app launch nonce' do
+      it 'allows the creator via app launch nonce when student scheduling is enabled' do
+        ConsumerConfig.create!(key: 'consumer-5', allow_student_scheduling: true)
         room = Room.create!(consumer_key: 'consumer-5')
         AppLaunch.create!(
           nonce: 'nonce-student-creator',
@@ -88,6 +89,32 @@ RSpec.describe Abilities, type: :model do
           created_by_launch_nonce: 'nonce-owner'
         )
         user = User.new(uid: 'student-other', roles: 'Student', launch_nonce: 'nonce-other')
+
+        expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
+      end
+
+      it 'denies creator when allow_student_scheduling is disabled' do
+        ConsumerConfig.create!(key: 'consumer-9', allow_student_scheduling: false)
+        room = Room.create!(consumer_key: 'consumer-9')
+        AppLaunch.create!(
+          nonce: 'nonce-student-creator-disabled',
+          params: {
+            'user_id' => 'student-5',
+            'context_id' => 'context-9',
+            'tool_consumer_instance_guid' => 'consumer-9',
+            'resource_link_id' => 'resource-9',
+            'custom_params' => { 'custom_enable_groups_scoping' => 'false' }
+          },
+          expires_at: Time.zone.now + 1.hour
+        )
+        meeting = ScheduledMeeting.create!(
+          room: room,
+          name: 'Student meeting',
+          start_at: Time.zone.now + 1.hour,
+          duration: 1800,
+          created_by_launch_nonce: 'nonce-student-creator-disabled'
+        )
+        user = User.new(uid: 'student-5', roles: 'Student', launch_nonce: 'nonce-student-creator-disabled')
 
         expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
       end

--- a/spec/models/abilities_spec.rb
+++ b/spec/models/abilities_spec.rb
@@ -1,110 +1,110 @@
 require 'rails_helper'
 
 RSpec.describe Abilities, type: :model do
-	describe '.can?' do
-		describe 'create scheduled meeting' do
-			it 'allows users with full permission' do
-				room = Room.create!(consumer_key: 'consumer-1')
-				user = User.new(uid: 'teacher-1', roles: 'Admin', launch_nonce: 'nonce-teacher')
+  describe '.can?' do
+    describe 'create scheduled meeting' do
+      it 'allows users with full permission' do
+        room = Room.create!(consumer_key: 'consumer-1')
+        user = User.new(uid: 'teacher-1', roles: 'Admin', launch_nonce: 'nonce-teacher')
 
-				expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(true)
-			end
+        expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(true)
+      end
 
-			it 'allows regular users when allow_student_scheduling is enabled' do
-				ConsumerConfig.create!(key: 'consumer-2', allow_student_scheduling: true)
-				room = Room.create!(consumer_key: 'consumer-2')
-				user = User.new(uid: 'student-1', roles: 'Student', launch_nonce: 'nonce-student')
+      it 'allows regular users when allow_student_scheduling is enabled' do
+        ConsumerConfig.create!(key: 'consumer-2', allow_student_scheduling: true)
+        room = Room.create!(consumer_key: 'consumer-2')
+        user = User.new(uid: 'student-1', roles: 'Student', launch_nonce: 'nonce-student')
 
-				expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(true)
-			end
+        expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(true)
+      end
 
-			it 'denies regular users when allow_student_scheduling is disabled' do
-				ConsumerConfig.create!(key: 'consumer-3', allow_student_scheduling: false)
-				room = Room.create!(consumer_key: 'consumer-3')
-				user = User.new(uid: 'student-2', roles: 'Student', launch_nonce: 'nonce-student-2')
+      it 'denies regular users when allow_student_scheduling is disabled' do
+        ConsumerConfig.create!(key: 'consumer-3', allow_student_scheduling: false)
+        room = Room.create!(consumer_key: 'consumer-3')
+        user = User.new(uid: 'student-2', roles: 'Student', launch_nonce: 'nonce-student-2')
 
-				expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(false)
-			end
-		end
+        expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(false)
+      end
+    end
 
-		describe 'manage scheduled meeting' do
-			it 'allows users with full permission' do
-				room = Room.create!(consumer_key: 'consumer-4')
-				meeting = ScheduledMeeting.create!(
-					room: room,
-					name: 'Weekly class',
-					start_at: Time.zone.now + 1.hour,
-					duration: 1800,
-					created_by_launch_nonce: 'nonce-creator'
-				)
-				user = User.new(uid: 'teacher-2', roles: 'Admin', launch_nonce: 'nonce-other')
+    describe 'manage scheduled meeting' do
+      it 'allows users with full permission' do
+        room = Room.create!(consumer_key: 'consumer-4')
+        meeting = ScheduledMeeting.create!(
+          room: room,
+          name: 'Weekly class',
+          start_at: Time.zone.now + 1.hour,
+          duration: 1800,
+          created_by_launch_nonce: 'nonce-creator'
+        )
+        user = User.new(uid: 'teacher-2', roles: 'Admin', launch_nonce: 'nonce-other')
 
-				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(true)
-			end
+        expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(true)
+      end
 
-			it 'allows the creator via app launch nonce' do
-				room = Room.create!(consumer_key: 'consumer-5')
-				AppLaunch.create!(
-					nonce: 'nonce-student-creator',
-					params: {
-						'user_id' => 'student-3',
-						'context_id' => 'context-5',
-						'tool_consumer_instance_guid' => 'consumer-5',
-						'resource_link_id' => 'resource-5',
-						'custom_params' => { 'custom_enable_groups_scoping' => 'false' }
-					},
-					expires_at: Time.zone.now + 1.hour
-				)
-				meeting = ScheduledMeeting.create!(
-					room: room,
-					name: 'Office hours',
-					start_at: Time.zone.now + 1.hour,
-					duration: 1800,
-					created_by_launch_nonce: 'nonce-student-creator'
-				)
-				user = User.new(uid: 'student-3', roles: 'Student', launch_nonce: 'nonce-student-creator')
+      it 'allows the creator via app launch nonce' do
+        room = Room.create!(consumer_key: 'consumer-5')
+        AppLaunch.create!(
+          nonce: 'nonce-student-creator',
+          params: {
+            'user_id' => 'student-3',
+            'context_id' => 'context-5',
+            'tool_consumer_instance_guid' => 'consumer-5',
+            'resource_link_id' => 'resource-5',
+            'custom_params' => { 'custom_enable_groups_scoping' => 'false' }
+          },
+          expires_at: Time.zone.now + 1.hour
+        )
+        meeting = ScheduledMeeting.create!(
+          room: room,
+          name: 'Office hours',
+          start_at: Time.zone.now + 1.hour,
+          duration: 1800,
+          created_by_launch_nonce: 'nonce-student-creator'
+        )
+        user = User.new(uid: 'student-3', roles: 'Student', launch_nonce: 'nonce-student-creator')
 
-				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(true)
-			end
+        expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(true)
+      end
 
-			it 'denies non-creator students' do
-				room = Room.create!(consumer_key: 'consumer-7')
-				AppLaunch.create!(
-					nonce: 'nonce-owner',
-					params: {
-						'user_id' => 'student-owner',
-						'context_id' => 'context-7',
-						'tool_consumer_instance_guid' => 'consumer-7',
-						'resource_link_id' => 'resource-7',
-						'custom_params' => { 'custom_enable_groups_scoping' => 'false' }
-					},
-					expires_at: Time.zone.now + 1.hour
-				)
-				meeting = ScheduledMeeting.create!(
-					room: room,
-					name: 'Lab',
-					start_at: Time.zone.now + 1.hour,
-					duration: 1800,
-					created_by_launch_nonce: 'nonce-owner'
-				)
-				user = User.new(uid: 'student-other', roles: 'Student', launch_nonce: 'nonce-other')
+      it 'denies non-creator students' do
+        room = Room.create!(consumer_key: 'consumer-7')
+        AppLaunch.create!(
+          nonce: 'nonce-owner',
+          params: {
+            'user_id' => 'student-owner',
+            'context_id' => 'context-7',
+            'tool_consumer_instance_guid' => 'consumer-7',
+            'resource_link_id' => 'resource-7',
+            'custom_params' => { 'custom_enable_groups_scoping' => 'false' }
+          },
+          expires_at: Time.zone.now + 1.hour
+        )
+        meeting = ScheduledMeeting.create!(
+          room: room,
+          name: 'Lab',
+          start_at: Time.zone.now + 1.hour,
+          duration: 1800,
+          created_by_launch_nonce: 'nonce-owner'
+        )
+        user = User.new(uid: 'student-other', roles: 'Student', launch_nonce: 'nonce-other')
 
-				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
-			end
+        expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
+      end
 
-			it 'denies access when app launch is missing (expired/deleted)' do
-				room = Room.create!(consumer_key: 'consumer-8')
-				meeting = ScheduledMeeting.create!(
-					room: room,
-					name: 'Old meeting',
-					start_at: Time.zone.now + 1.hour,
-					duration: 1800,
-					created_by_launch_nonce: 'nonce-expired'
-				)
-				user = User.new(uid: 'student-4', roles: 'Student', launch_nonce: 'nonce-student-4')
+      it 'denies access when app launch is missing (expired/deleted)' do
+        room = Room.create!(consumer_key: 'consumer-8')
+        meeting = ScheduledMeeting.create!(
+          room: room,
+          name: 'Old meeting',
+          start_at: Time.zone.now + 1.hour,
+          duration: 1800,
+          created_by_launch_nonce: 'nonce-expired'
+        )
+        user = User.new(uid: 'student-4', roles: 'Student', launch_nonce: 'nonce-student-4')
 
-				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
-			end
-		end
-	end
+        expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
+      end
+    end
+  end
 end

--- a/themes/elos/assets/stylesheets/theme-application-elos.scss
+++ b/themes/elos/assets/stylesheets/theme-application-elos.scss
@@ -76,6 +76,12 @@ body.theme-elos {
       color: var(--color-gray-05);
     }
 
+    .item-creator {
+      font-size: 16px;
+      margin-top: 4px;
+      color: var(--color-gray-05);
+    }
+
     tr {
       margin-left: 0;
       margin-right: 0;

--- a/themes/elos/config/locales/en.yml
+++ b/themes/elos/config/locales/en.yml
@@ -124,6 +124,7 @@ en:
       entering: "Acessing..."
       title: "Classes"
   scheduled_meetings:
+    created_by: "Created by %{name}"
     destroy: "Remove"
     edit:
       action: "Edit"

--- a/themes/elos/config/locales/es.yml
+++ b/themes/elos/config/locales/es.yml
@@ -124,6 +124,7 @@ es:
       entering: "Accediendo..."
       title: "Clases"
   scheduled_meetings:
+    created_by: "Creado por %{name}"
     destroy: "Eliminar"
     edit:
       action: "Editar"

--- a/themes/elos/config/locales/pt.yml
+++ b/themes/elos/config/locales/pt.yml
@@ -124,6 +124,7 @@ pt:
       entering: "Acessando..."
       title: "Turmas"
   scheduled_meetings:
+    created_by: "Criado por %{name}"
     destroy: "Remover"
     edit:
       action: "Editar"

--- a/themes/elos/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/elos/views/shared/_scheduled_meeting_row.html.erb
@@ -4,6 +4,10 @@
     <% unless meeting.description.blank? %>
       <div class="item-description word-break"><%= meeting.description %></div>
     <% end %>
+    <% creator = meeting.creator_name %>
+    <% unless creator.blank? %>
+      <div class="item-creator"><%= t('scheduled_meetings.created_by', name: creator) %></div>
+    <% end %>
   </td>
   <td class="col-12 col-md-3 align-middle">
     <%= format_date(meeting.start_at) %>
@@ -31,7 +35,7 @@
     <% end %>
   </td>
   <td class="col-2 col-md-1 align-middle td-dropdown-opts">
-    <% if can_edit?(user, room) %>
+    <% if can_manage_scheduled_meeting?(user, meeting) %>
       <div class="dropdown dropdown-opts">
         <a href="#" class="dropdown-toggle d-flex text-decoration-none" id="dropdown-opts-<%= room.to_param %>" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <i class="icon material-icons">more_vert</i>

--- a/themes/elos/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/elos/views/shared/_scheduled_meeting_row.html.erb
@@ -4,9 +4,11 @@
     <% unless meeting.description.blank? %>
       <div class="item-description word-break"><%= meeting.description %></div>
     <% end %>
-    <% creator = meeting.creator_name %>
-    <% unless creator.blank? %>
-      <div class="item-creator"><%= t('scheduled_meetings.created_by', name: creator) %></div>
+    <% if allow_student_scheduling?(room) %>
+      <% creator = meeting.creator_name %>
+      <% unless creator.blank? %>
+        <div class="item-creator"><%= t('scheduled_meetings.created_by', name: creator) %></div>
+      <% end %>
     <% end %>
   </td>
   <td class="col-12 col-md-3 align-middle">

--- a/themes/elos/views/shared/_scheduled_meetings.html.erb
+++ b/themes/elos/views/shared/_scheduled_meetings.html.erb
@@ -10,7 +10,7 @@
     </div>
   <% end %>
 
-  <% if can_edit?(user, room) %>
+  <% if can_create_scheduled_meeting?(user, room) %>
     <div id="view-meetings" class="col-12 col-sm-12 col-md-4 col-lg-4">
   <% else %>
     <div id="view-meetings" class="col-12 col-sm-6 col-md-6 col-lg-4 offset-lg-4">
@@ -23,7 +23,7 @@
     %>
   </div>
 
-    <% if can_edit?(user, room) %>
+    <% if can_create_scheduled_meeting?(user, room) %>
     <div id="schedule-meeting" class="col-12 col-sm-12 col-md-4 col-lg-4">
       <%=
       link_to t('scheduled_meetings.new.add'),

--- a/themes/rnp/assets/stylesheets/theme-application-rnp.scss
+++ b/themes/rnp/assets/stylesheets/theme-application-rnp.scss
@@ -79,6 +79,12 @@ body.theme-rnp {
       color: var(--color-gray-05);
     }
 
+    .item-creator {
+      font-size: 16px;
+      margin-top: 4px;
+      color: var(--color-gray-05);
+    }
+
     tr {
       margin-left: 0;
       margin-right: 0;

--- a/themes/rnp/config/locales/en.yml
+++ b/themes/rnp/config/locales/en.yml
@@ -166,6 +166,7 @@ en:
       message: "Thank you for participating and until the next time."
       title: "Your session has ended"
   scheduled_meetings:
+    created_by: "Created by %{name}"
     destroy: "Remove"
     edit:
       action: "Edit"

--- a/themes/rnp/config/locales/es.yml
+++ b/themes/rnp/config/locales/es.yml
@@ -166,6 +166,7 @@ es:
       message: "Gracias por su participación y hasta luego."
       title: "Tu sesión ha terminado"
   scheduled_meetings:
+    created_by: "Creado por %{name}"
     destroy: "Eliminar"
     edit:
       action: "Editar"

--- a/themes/rnp/config/locales/pt.yml
+++ b/themes/rnp/config/locales/pt.yml
@@ -166,6 +166,7 @@ pt:
       message: "Obrigado pela sua participação e até a próxima."
       title: "Sua sessão acabou"
   scheduled_meetings:
+    created_by: "Criado por %{name}"
     destroy: "Remover"
     edit:
       action: "Editar"

--- a/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
@@ -4,6 +4,10 @@
     <% unless meeting.description.blank? %>
       <div class="item-description word-break"><%= meeting.description %></div>
     <% end %>
+    <% creator = meeting.creator_name %>
+    <% unless creator.blank? %>
+      <div class="item-creator"><%= t('scheduled_meetings.created_by', name: creator) %></div>
+    <% end %>
   </td>
   <td class="col-12 col-md-3 align-middle">
     <%= format_date(meeting.start_at) %>
@@ -39,7 +43,7 @@
     <% end %>
   </td>
   <td class="col-2 col-md-1 align-middle td-dropdown-opts">
-    <% if can_edit?(user, room) %>
+    <% if can_manage_scheduled_meeting?(user, meeting) %>
       <div class="dropdown dropdown-opts">
         <a href="#" class="dropdown-toggle d-flex text-decoration-none" id="dropdown-opts-<%= room.to_param %>" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <i class="icon material-icons">more_vert</i>

--- a/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
@@ -4,9 +4,11 @@
     <% unless meeting.description.blank? %>
       <div class="item-description word-break"><%= meeting.description %></div>
     <% end %>
-    <% creator = meeting.creator_name %>
-    <% unless creator.blank? %>
-      <div class="item-creator"><%= t('scheduled_meetings.created_by', name: creator) %></div>
+    <% if allow_student_scheduling?(room) %>
+      <% creator = meeting.creator_name %>
+      <% unless creator.blank? %>
+        <div class="item-creator"><%= t('scheduled_meetings.created_by', name: creator) %></div>
+      <% end %>
     <% end %>
   </td>
   <td class="col-12 col-md-3 align-middle">

--- a/themes/rnp/views/shared/_scheduled_meetings.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meetings.html.erb
@@ -11,7 +11,7 @@
     </div>
   <% end %>
 
-  <% if can_edit?(user, room) %>
+  <% if can_create_scheduled_meeting?(user, room) %>
     <div id="view-meetings" class="col-12 col-sm-12 col-md-4 col-lg-4">
   <% else %>
     <div id="view-meetings" class="col-12 col-sm-6 col-md-6 col-lg-4 offset-lg-4">
@@ -25,7 +25,7 @@
     %>
   </div>
 
-  <% if can_edit?(user, room) %>
+  <% if can_create_scheduled_meeting?(user, room) %>
     <div id="schedule-meeting" class="col-12 col-sm-12 col-md-4 col-lg-4">
       <%=
       link_to t('scheduled_meetings.new.add'),


### PR DESCRIPTION
This pull request introduces enhanced authorization for scheduled meetings, allowing fine-grained control over who can create and manage meetings. It also adds attribution for meeting creators in the UI, and updates the database and localization files to support these features. The most important changes are grouped below:

**Authorization and Permissions:**

* Added new abilities: `create_scheduled_meeting` and `manage_scheduled_meeting`, allowing users with full permissions or, conditionally, students (if enabled in the consumer config) to create meetings, and restricting management (edit/update/destroy) to meeting creators or users with full permissions. [[1]](diffhunk://#diff-5c13b1e3830e2c43ffec5fc4d1b257910d2383eeb14fc7d84722745fdcd29d78R25-R28) [[2]](diffhunk://#diff-5c13b1e3830e2c43ffec5fc4d1b257910d2383eeb14fc7d84722745fdcd29d78R41-R64) [[3]](diffhunk://#diff-d0979ef242d14e6a0cca98c30a2b44fb09f7bc0bf67bb202e6d0d9ecc98f3b99L30-R34) [[4]](diffhunk://#diff-5f3fc5e3977d242572aa1d08551f5eb557de0ccaff30370838ee9df5386ea0daR42-R49) [[5]](diffhunk://#diff-2e5514a27c859fad9e0d0be6ceb008ce04063db25eb27fbf462ee71b599564abR4-R109)
* Updated controller actions and helper methods to use the new permission checks (`can_create_scheduled_meeting?`, `can_manage_scheduled_meeting?`) instead of the previous generic edit checks. [[1]](diffhunk://#diff-2e0d9379f84f1ee64883a0961f79125770120c81eddaa1074050c27eaf71adc8L13-R13) [[2]](diffhunk://#diff-2e0d9379f84f1ee64883a0961f79125770120c81eddaa1074050c27eaf71adc8L26-R26) [[3]](diffhunk://#diff-43bc535d82a9a89532f6bbd280cefe0e0acda222a7fed3c6350df5c8a45b181fL34-R38) [[4]](diffhunk://#diff-a298f23401fe5167f58d90e148d0a6f3d23eaf739ddb4fb8e52d63c6adb19cb9L42-R46)

**Database and Model Enhancements:**

* Added a new boolean column `allow_student_scheduling` to the `consumer_configs` table, defaulting to false, to control whether students can schedule meetings. [[1]](diffhunk://#diff-b05a4df55aa69f384c9e98f0566237e347e24327db57c264977c6f97207bcea5R1-R5) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R74)
* Associated `ScheduledMeeting` with its `creator_launch` (`AppLaunch`), and added a `creator_name` method to retrieve the creator's display name. [[1]](diffhunk://#diff-1d8a0157fda7b651248f0d740fa3c0e46dffcc1d5d1b7eac0912f402ba08dbacR12) [[2]](diffhunk://#diff-1d8a0157fda7b651248f0d740fa3c0e46dffcc1d5d1b7eac0912f402ba08dbacR279-R282)

**User Interface Improvements:**

* Displayed the creator's name for each scheduled meeting in both the Elos and RNP themes, with appropriate styling. [[1]](diffhunk://#diff-43bc535d82a9a89532f6bbd280cefe0e0acda222a7fed3c6350df5c8a45b181fR7-R10) [[2]](diffhunk://#diff-a298f23401fe5167f58d90e148d0a6f3d23eaf739ddb4fb8e52d63c6adb19cb9R7-R10) [[3]](diffhunk://#diff-91ec682a8f6de35adafc703c14d1744d22a15e4403f88fa504a656ed35037c4dR79-R84) [[4]](diffhunk://#diff-ebdf14e2960d00b5d3304f5d6263175a20cb6a1c4900ac75f09338b25c4ee3e8R82-R87)

**Localization:**

* Added the `created_by` translation for scheduled meetings in English, Spanish, and Portuguese for both Elos and RNP themes. [[1]](diffhunk://#diff-3669f7f9d02d31ca6be387fce4381e4b4f46525afbaf817477b01d374d1aea33R127) [[2]](diffhunk://#diff-ac83b690a42860a8a0f9da4342789eca4e8f860b708d22b4dc060a98275092f6R127) [[3]](diffhunk://#diff-a14cafcda313954899ba0bc967eea246312948ec8be4dac83f731d541b7268c5R127) [[4]](diffhunk://#diff-addfa363259a6819bfcb367cd531ddc8724349d473be27cb557f4d427c312ed6R169) [[5]](diffhunk://#diff-0c813a56e4af16c957a7f5302cfe56433fd3f36d072e9af3d5ee13f243a827a5R169) [[6]](diffhunk://#diff-082a68375a031c82649ecbc9fa6aefa0d29ca338c3771b872e63c17b60f445a6R169)

**Performance:**

* Optimized queries by eager-loading the `creator_launch` association when fetching scheduled meetings, reducing N+1 queries. [[1]](diffhunk://#diff-766c34fd6533171eaf54300c153f89d6002c35c02cfc9c5b219251f85180ad07L172-R172) [[2]](diffhunk://#diff-16e9830311185de1ace2bb01b491a8e704f74aaebeeab2a0d21a72cb090f261eL43-R43)

These changes together provide more granular meeting permissions, improve the user experience by showing meeting creators, and ensure the system is ready for student-scheduled meetings where permitted.