### PR TITLE
[PRT-2624] Replace Blip chat widget with Ipezinho widget

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -169,7 +169,7 @@ class ApplicationController < ActionController::Base
   end
 
   def find_scheduled_meeting
-    @scheduled_meeting = @room.scheduled_meetings.from_param(params[:id])
+    @scheduled_meeting = @room.scheduled_meetings.includes(:creator_launch).from_param(params[:id])
   end
 
   def validate_scheduled_meeting

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -424,7 +424,8 @@ class RoomsController < ApplicationController
       external_widget: custom_params['external_widget'],
       external_disclaimer: custom_params['external_disclaimer'],
       external_context_url: custom_params['external_context_url'],
-      institution_guid: custom_params['institution_guid']
+      institution_guid: custom_params['institution_guid'],
+      allow_student_scheduling: custom_params['allow_student_scheduling']
     )
     Rails.logger.info "[setup_consumer_configs] ConsumerConfig created/updated with key=#{@consumer_config.key}, " \
     "params=#{custom_params.except('bbb', 'moodle', 'brightspace')}"

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -40,7 +40,7 @@ class RoomsController < ApplicationController
   def show
     respond_to do |format|
       @room.update_recurring_meetings
-      @scheduled_meetings = @room.scheduled_meetings.active
+      @scheduled_meetings = @room.scheduled_meetings.active.includes(:creator_launch)
 
       if @room.moodle_group_select_enabled?
         @scheduled_meetings = @scheduled_meetings.where(moodle_group_id: Rails.cache.read("#{@app_launch.nonce}/current_group_id"))

--- a/app/controllers/scheduled_meetings_controller.rb
+++ b/app/controllers/scheduled_meetings_controller.rb
@@ -27,8 +27,11 @@ class ScheduledMeetingsController < ApplicationController
   before_action only: %i[join external wait] do
     authorize_user!(:show, @scheduled_meeting) if @user.present?
   end
-  before_action only: %i[new create edit update destroy] do
-    authorize_user!(:edit, @room)
+  before_action only: %i[new create] do
+    authorize_user!(:create_scheduled_meeting, @room)
+  end
+  before_action only: %i[edit update destroy] do
+    authorize_user!(:manage_scheduled_meeting, @scheduled_meeting)
   end
 
   before_action :set_blank_repeat_as_nil, only: %i[create update]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,6 +39,14 @@ module ApplicationHelper
     Abilities.can?(user, :download_presentation_video, resource)
   end
 
+  def can_create_scheduled_meeting?(user, room)
+    Abilities.can?(user, :create_scheduled_meeting, room)
+  end
+
+  def can_manage_scheduled_meeting?(user, meeting)
+    Abilities.can?(user, :manage_scheduled_meeting, meeting)
+  end
+
   def show_terms_use_message?(resource)
     config = ConsumerConfig.find_by(key: resource[:consumer_key])
     config.present? && config[:message_reference_terms_use]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,6 +47,10 @@ module ApplicationHelper
     Abilities.can?(user, :manage_scheduled_meeting, meeting)
   end
 
+  def allow_student_scheduling?(room)
+    Abilities.allow_student_scheduling?(room)
+  end
+
   def show_terms_use_message?(resource)
     config = ConsumerConfig.find_by(key: resource[:consumer_key])
     config.present? && config[:message_reference_terms_use]

--- a/app/models/abilities.rb
+++ b/app/models/abilities.rb
@@ -1,5 +1,7 @@
 class Abilities
 
+  ALLOW_STUDENT_SCHEDULING_CACHE_KEY = :abilities_allow_student_scheduling_cache
+
   # This is a simplified authorization mechanism
   # TODO: verifiy the resource as well
   def self.can?(user, action, resource)
@@ -42,8 +44,15 @@ class Abilities
   def self.allow_student_scheduling?(resource)
     return false if resource.blank?
 
-    config = ConsumerConfig.select(:allow_student_scheduling).find_by(key: resource.consumer_key)
-    config.present? && config.allow_student_scheduling?
+    consumer_key = resource.consumer_key
+    return false if consumer_key.blank?
+
+    # Keep this cache to avoid repeated queries during a single render
+    cache = ActiveSupport::IsolatedExecutionState[ALLOW_STUDENT_SCHEDULING_CACHE_KEY] ||= {}
+    return cache[consumer_key] if cache.key?(consumer_key)
+
+    config = ConsumerConfig.select(:allow_student_scheduling).find_by(key: consumer_key)
+    cache[consumer_key] = config.present? && config.allow_student_scheduling?
   end
 
   def self.user_created_meeting?(user, resource)

--- a/app/models/abilities.rb
+++ b/app/models/abilities.rb
@@ -1,7 +1,6 @@
 class Abilities
 
-  # This is a simplified authorization mechanism that has three actions:
-  # :show, :edit and :admin
+  # This is a simplified authorization mechanism
   # TODO: verifiy the resource as well
   def self.can?(user, action, resource)
     case action
@@ -23,6 +22,10 @@ class Abilities
       end
     when :download_artifacts
       user.present? && self.full_permission?(user)
+    when :create_scheduled_meeting
+      user.present? && (self.full_permission?(user) || self.allow_student_scheduling?(resource))
+    when :manage_scheduled_meeting
+      user.present? && (self.full_permission?(user) || self.user_created_meeting?(user, resource))
     else
       false
     end
@@ -34,5 +37,29 @@ class Abilities
 
   def self.moderator_roles
     Rails.configuration.bigbluebutton_moderator_roles.split(',')
+  end
+
+  def self.allow_student_scheduling?(resource)
+    return false if resource.blank?
+
+    config = ConsumerConfig.select(:allow_student_scheduling).find_by(key: resource.consumer_key)
+    config.present? && config.allow_student_scheduling?
+  end
+
+  def self.user_created_meeting?(user, resource)
+    return false if resource.blank? || user.blank?
+
+    nonce = resource.created_by_launch_nonce
+    return false if nonce.blank?
+
+    app_launch = if resource.association(:creator_launch).loaded?
+                   resource.creator_launch
+                 else
+                   AppLaunch.select(:params).find_by(nonce: nonce)
+                 end
+    return false if app_launch.blank?
+
+    creator_uid = app_launch.params&.[]('user_id')
+    creator_uid.present? && creator_uid == user.uid
   end
 end

--- a/app/models/abilities.rb
+++ b/app/models/abilities.rb
@@ -25,7 +25,7 @@ class Abilities
     when :create_scheduled_meeting
       user.present? && (self.full_permission?(user) || self.allow_student_scheduling?(resource))
     when :manage_scheduled_meeting
-      user.present? && (self.full_permission?(user) || self.user_created_meeting?(user, resource))
+      user.present? && (self.full_permission?(user) || (self.allow_student_scheduling?(resource) && self.user_created_meeting?(user, resource)))
     else
       false
     end
@@ -42,7 +42,11 @@ class Abilities
   def self.allow_student_scheduling?(resource)
     return false if resource.blank?
 
-    config = ConsumerConfig.select(:allow_student_scheduling).find_by(key: resource.consumer_key)
+    # Handle both Room and ScheduledMeeting resources
+    consumer_key = resource.is_a?(ScheduledMeeting) ? resource.room&.consumer_key : resource.consumer_key
+    return false if consumer_key.blank?
+
+    config = ConsumerConfig.select(:allow_student_scheduling).find_by(key: consumer_key)
     config.present? && config.allow_student_scheduling?
   end
 

--- a/app/models/abilities.rb
+++ b/app/models/abilities.rb
@@ -1,7 +1,5 @@
 class Abilities
 
-  ALLOW_STUDENT_SCHEDULING_CACHE_KEY = :abilities_allow_student_scheduling_cache
-
   # This is a simplified authorization mechanism
   # TODO: verifiy the resource as well
   def self.can?(user, action, resource)
@@ -44,15 +42,8 @@ class Abilities
   def self.allow_student_scheduling?(resource)
     return false if resource.blank?
 
-    consumer_key = resource.consumer_key
-    return false if consumer_key.blank?
-
-    # Keep this cache to avoid repeated queries during a single render
-    cache = ActiveSupport::IsolatedExecutionState[ALLOW_STUDENT_SCHEDULING_CACHE_KEY] ||= {}
-    return cache[consumer_key] if cache.key?(consumer_key)
-
-    config = ConsumerConfig.select(:allow_student_scheduling).find_by(key: consumer_key)
-    cache[consumer_key] = config.present? && config.allow_student_scheduling?
+    config = ConsumerConfig.select(:allow_student_scheduling).find_by(key: resource.consumer_key)
+    config.present? && config.allow_student_scheduling?
   end
 
   def self.user_created_meeting?(user, resource)

--- a/app/models/scheduled_meeting.rb
+++ b/app/models/scheduled_meeting.rb
@@ -9,6 +9,7 @@ class ScheduledMeeting < ApplicationRecord
   }.stringify_keys.freeze
 
   belongs_to :room
+  belongs_to :creator_launch, class_name: 'AppLaunch', primary_key: 'nonce', foreign_key: 'created_by_launch_nonce', optional: true
   has_one :brightspace_calendar_event,
           primary_key: :hash_id,
           foreign_key: :scheduled_meeting_hash_id,
@@ -273,6 +274,10 @@ class ScheduledMeeting < ApplicationRecord
 
   def self.default_duration_for_helper
     return 60 * 60 # 1h
+  end
+
+  def creator_name
+    @creator_name ||= creator_launch&.params&.[]('lis_person_name_full')
   end
 
   private

--- a/config/application.rb
+++ b/config/application.rb
@@ -140,8 +140,6 @@ module BbbAppRooms
     config.filesender_service_url       = Mconf::Env.fetch('MCONF_FILESENDER_SERVICE_URL')
     config.filesender_client_secret     = Mconf::Env.fetch('MCONF_FILESENDER_CLIENT_SECRET')
 
-    # RNP CHAT
-
     # Moodle API
     config.moodle_api_timeout = Mconf::Env.fetch_int('MCONF_MOODLE_API_TIMEOUT', 5)
     config.moodle_recurring_events_month_period = Mconf::Env.fetch_int('MCONF_MOODLE_RECURRING_EVENTS_MONTH_PERIOD', 12)

--- a/config/application.rb
+++ b/config/application.rb
@@ -141,7 +141,6 @@ module BbbAppRooms
     config.filesender_client_secret     = Mconf::Env.fetch('MCONF_FILESENDER_CLIENT_SECRET')
 
     # RNP CHAT
-    config.rnp_chat_id = Mconf::Env.fetch('RNP_CHAT_ID', '')
 
     # Moodle API
     config.moodle_api_timeout = Mconf::Env.fetch_int('MCONF_MOODLE_API_TIMEOUT', 5)

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ Bundler.require(*Rails.groups)
 
 module BbbAppRooms
   class Application < Rails::Application
-    VERSION = "1.2.0"
+    VERSION = "1.3.0"
 
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.0

--- a/db/migrate/20260223182237_add_allow_student_scheduling_to_consumer_configs.rb
+++ b/db/migrate/20260223182237_add_allow_student_scheduling_to_consumer_configs.rb
@@ -1,0 +1,5 @@
+class AddAllowStudentSchedulingToConsumerConfigs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :consumer_configs, :allow_student_scheduling, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_16_103515) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_23_182237) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -71,6 +71,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_16_103515) do
     t.boolean "force_disable_external_link", default: false
     t.string "external_context_url"
     t.string "institution_guid"
+    t.boolean "allow_student_scheduling", default: false, null: false
     t.index ["key"], name: "index_consumer_configs_on_key", unique: true
   end
 
@@ -159,7 +160,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_16_103515) do
     t.integer "moodle_group_id"
     t.string "moodle_group_name"
     t.boolean "mark_moodle_attendance"
-    t.boolean "mark_brightspace_attendance"
+    t.boolean "mark_brightspace_attendance", default: false, null: false
     t.index ["created_by_launch_nonce"], name: "index_scheduled_meetings_on_created_by_launch_nonce"
     t.index ["hash_id"], name: "index_scheduled_meetings_on_hash_id", unique: true
     t.index ["repeat"], name: "index_scheduled_meetings_on_repeat"

--- a/spec/models/abilities_spec.rb
+++ b/spec/models/abilities_spec.rb
@@ -1,4 +1,110 @@
 require 'rails_helper'
 
 RSpec.describe Abilities, type: :model do
+	describe '.can?' do
+		describe 'create scheduled meeting' do
+			it 'allows users with full permission' do
+				room = Room.create!(consumer_key: 'consumer-1')
+				user = User.new(uid: 'teacher-1', roles: 'Admin', launch_nonce: 'nonce-teacher')
+
+				expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(true)
+			end
+
+			it 'allows regular users when allow_student_scheduling is enabled' do
+				ConsumerConfig.create!(key: 'consumer-2', allow_student_scheduling: true)
+				room = Room.create!(consumer_key: 'consumer-2')
+				user = User.new(uid: 'student-1', roles: 'Student', launch_nonce: 'nonce-student')
+
+				expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(true)
+			end
+
+			it 'denies regular users when allow_student_scheduling is disabled' do
+				ConsumerConfig.create!(key: 'consumer-3', allow_student_scheduling: false)
+				room = Room.create!(consumer_key: 'consumer-3')
+				user = User.new(uid: 'student-2', roles: 'Student', launch_nonce: 'nonce-student-2')
+
+				expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(false)
+			end
+		end
+
+		describe 'manage scheduled meeting' do
+			it 'allows users with full permission' do
+				room = Room.create!(consumer_key: 'consumer-4')
+				meeting = ScheduledMeeting.create!(
+					room: room,
+					name: 'Weekly class',
+					start_at: Time.zone.now + 1.hour,
+					duration: 1800,
+					created_by_launch_nonce: 'nonce-creator'
+				)
+				user = User.new(uid: 'teacher-2', roles: 'Admin', launch_nonce: 'nonce-other')
+
+				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(true)
+			end
+
+			it 'allows the creator via app launch nonce' do
+				room = Room.create!(consumer_key: 'consumer-5')
+				AppLaunch.create!(
+					nonce: 'nonce-student-creator',
+					params: {
+						'user_id' => 'student-3',
+						'context_id' => 'context-5',
+						'tool_consumer_instance_guid' => 'consumer-5',
+						'resource_link_id' => 'resource-5',
+						'custom_params' => { 'custom_enable_groups_scoping' => 'false' }
+					},
+					expires_at: Time.zone.now + 1.hour
+				)
+				meeting = ScheduledMeeting.create!(
+					room: room,
+					name: 'Office hours',
+					start_at: Time.zone.now + 1.hour,
+					duration: 1800,
+					created_by_launch_nonce: 'nonce-student-creator'
+				)
+				user = User.new(uid: 'student-3', roles: 'Student', launch_nonce: 'nonce-student-creator')
+
+				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(true)
+			end
+
+			it 'denies non-creator students' do
+				room = Room.create!(consumer_key: 'consumer-7')
+				AppLaunch.create!(
+					nonce: 'nonce-owner',
+					params: {
+						'user_id' => 'student-owner',
+						'context_id' => 'context-7',
+						'tool_consumer_instance_guid' => 'consumer-7',
+						'resource_link_id' => 'resource-7',
+						'custom_params' => { 'custom_enable_groups_scoping' => 'false' }
+					},
+					expires_at: Time.zone.now + 1.hour
+				)
+				meeting = ScheduledMeeting.create!(
+					room: room,
+					name: 'Lab',
+					start_at: Time.zone.now + 1.hour,
+					duration: 1800,
+					created_by_launch_nonce: 'nonce-owner'
+				)
+				user = User.new(uid: 'student-other', roles: 'Student', launch_nonce: 'nonce-other')
+
+				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
+			end
+
+			it 'denies access when app launch is missing (expired/deleted)' do
+				room = Room.create!(consumer_key: 'consumer-8')
+				meeting = ScheduledMeeting.create!(
+					room: room,
+					name: 'Old meeting',
+					start_at: Time.zone.now + 1.hour,
+					duration: 1800,
+					created_by_launch_nonce: 'nonce-expired'
+				)
+				user = User.new(uid: 'student-4', roles: 'Student', launch_nonce: 'nonce-student-4')
+
+				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
+			end
+		end
+	end
 end

--- a/spec/models/abilities_spec.rb
+++ b/spec/models/abilities_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe Abilities, type: :model do
         expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(true)
       end
 
-      it 'allows the creator via app launch nonce' do
+      it 'allows the creator via app launch nonce when student scheduling is enabled' do
+        ConsumerConfig.create!(key: 'consumer-5', allow_student_scheduling: true)
         room = Room.create!(consumer_key: 'consumer-5')
         AppLaunch.create!(
           nonce: 'nonce-student-creator',
@@ -88,6 +89,32 @@ RSpec.describe Abilities, type: :model do
           created_by_launch_nonce: 'nonce-owner'
         )
         user = User.new(uid: 'student-other', roles: 'Student', launch_nonce: 'nonce-other')
+
+        expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
+      end
+
+      it 'denies creator when allow_student_scheduling is disabled' do
+        ConsumerConfig.create!(key: 'consumer-9', allow_student_scheduling: false)
+        room = Room.create!(consumer_key: 'consumer-9')
+        AppLaunch.create!(
+          nonce: 'nonce-student-creator-disabled',
+          params: {
+            'user_id' => 'student-5',
+            'context_id' => 'context-9',
+            'tool_consumer_instance_guid' => 'consumer-9',
+            'resource_link_id' => 'resource-9',
+            'custom_params' => { 'custom_enable_groups_scoping' => 'false' }
+          },
+          expires_at: Time.zone.now + 1.hour
+        )
+        meeting = ScheduledMeeting.create!(
+          room: room,
+          name: 'Student meeting',
+          start_at: Time.zone.now + 1.hour,
+          duration: 1800,
+          created_by_launch_nonce: 'nonce-student-creator-disabled'
+        )
+        user = User.new(uid: 'student-5', roles: 'Student', launch_nonce: 'nonce-student-creator-disabled')
 
         expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
       end

--- a/spec/models/abilities_spec.rb
+++ b/spec/models/abilities_spec.rb
@@ -1,110 +1,110 @@
 require 'rails_helper'
 
 RSpec.describe Abilities, type: :model do
-	describe '.can?' do
-		describe 'create scheduled meeting' do
-			it 'allows users with full permission' do
-				room = Room.create!(consumer_key: 'consumer-1')
-				user = User.new(uid: 'teacher-1', roles: 'Admin', launch_nonce: 'nonce-teacher')
+  describe '.can?' do
+    describe 'create scheduled meeting' do
+      it 'allows users with full permission' do
+        room = Room.create!(consumer_key: 'consumer-1')
+        user = User.new(uid: 'teacher-1', roles: 'Admin', launch_nonce: 'nonce-teacher')
 
-				expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(true)
-			end
+        expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(true)
+      end
 
-			it 'allows regular users when allow_student_scheduling is enabled' do
-				ConsumerConfig.create!(key: 'consumer-2', allow_student_scheduling: true)
-				room = Room.create!(consumer_key: 'consumer-2')
-				user = User.new(uid: 'student-1', roles: 'Student', launch_nonce: 'nonce-student')
+      it 'allows regular users when allow_student_scheduling is enabled' do
+        ConsumerConfig.create!(key: 'consumer-2', allow_student_scheduling: true)
+        room = Room.create!(consumer_key: 'consumer-2')
+        user = User.new(uid: 'student-1', roles: 'Student', launch_nonce: 'nonce-student')
 
-				expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(true)
-			end
+        expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(true)
+      end
 
-			it 'denies regular users when allow_student_scheduling is disabled' do
-				ConsumerConfig.create!(key: 'consumer-3', allow_student_scheduling: false)
-				room = Room.create!(consumer_key: 'consumer-3')
-				user = User.new(uid: 'student-2', roles: 'Student', launch_nonce: 'nonce-student-2')
+      it 'denies regular users when allow_student_scheduling is disabled' do
+        ConsumerConfig.create!(key: 'consumer-3', allow_student_scheduling: false)
+        room = Room.create!(consumer_key: 'consumer-3')
+        user = User.new(uid: 'student-2', roles: 'Student', launch_nonce: 'nonce-student-2')
 
-				expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(false)
-			end
-		end
+        expect(Abilities.can?(user, :create_scheduled_meeting, room)).to be(false)
+      end
+    end
 
-		describe 'manage scheduled meeting' do
-			it 'allows users with full permission' do
-				room = Room.create!(consumer_key: 'consumer-4')
-				meeting = ScheduledMeeting.create!(
-					room: room,
-					name: 'Weekly class',
-					start_at: Time.zone.now + 1.hour,
-					duration: 1800,
-					created_by_launch_nonce: 'nonce-creator'
-				)
-				user = User.new(uid: 'teacher-2', roles: 'Admin', launch_nonce: 'nonce-other')
+    describe 'manage scheduled meeting' do
+      it 'allows users with full permission' do
+        room = Room.create!(consumer_key: 'consumer-4')
+        meeting = ScheduledMeeting.create!(
+          room: room,
+          name: 'Weekly class',
+          start_at: Time.zone.now + 1.hour,
+          duration: 1800,
+          created_by_launch_nonce: 'nonce-creator'
+        )
+        user = User.new(uid: 'teacher-2', roles: 'Admin', launch_nonce: 'nonce-other')
 
-				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(true)
-			end
+        expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(true)
+      end
 
-			it 'allows the creator via app launch nonce' do
-				room = Room.create!(consumer_key: 'consumer-5')
-				AppLaunch.create!(
-					nonce: 'nonce-student-creator',
-					params: {
-						'user_id' => 'student-3',
-						'context_id' => 'context-5',
-						'tool_consumer_instance_guid' => 'consumer-5',
-						'resource_link_id' => 'resource-5',
-						'custom_params' => { 'custom_enable_groups_scoping' => 'false' }
-					},
-					expires_at: Time.zone.now + 1.hour
-				)
-				meeting = ScheduledMeeting.create!(
-					room: room,
-					name: 'Office hours',
-					start_at: Time.zone.now + 1.hour,
-					duration: 1800,
-					created_by_launch_nonce: 'nonce-student-creator'
-				)
-				user = User.new(uid: 'student-3', roles: 'Student', launch_nonce: 'nonce-student-creator')
+      it 'allows the creator via app launch nonce' do
+        room = Room.create!(consumer_key: 'consumer-5')
+        AppLaunch.create!(
+          nonce: 'nonce-student-creator',
+          params: {
+            'user_id' => 'student-3',
+            'context_id' => 'context-5',
+            'tool_consumer_instance_guid' => 'consumer-5',
+            'resource_link_id' => 'resource-5',
+            'custom_params' => { 'custom_enable_groups_scoping' => 'false' }
+          },
+          expires_at: Time.zone.now + 1.hour
+        )
+        meeting = ScheduledMeeting.create!(
+          room: room,
+          name: 'Office hours',
+          start_at: Time.zone.now + 1.hour,
+          duration: 1800,
+          created_by_launch_nonce: 'nonce-student-creator'
+        )
+        user = User.new(uid: 'student-3', roles: 'Student', launch_nonce: 'nonce-student-creator')
 
-				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(true)
-			end
+        expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(true)
+      end
 
-			it 'denies non-creator students' do
-				room = Room.create!(consumer_key: 'consumer-7')
-				AppLaunch.create!(
-					nonce: 'nonce-owner',
-					params: {
-						'user_id' => 'student-owner',
-						'context_id' => 'context-7',
-						'tool_consumer_instance_guid' => 'consumer-7',
-						'resource_link_id' => 'resource-7',
-						'custom_params' => { 'custom_enable_groups_scoping' => 'false' }
-					},
-					expires_at: Time.zone.now + 1.hour
-				)
-				meeting = ScheduledMeeting.create!(
-					room: room,
-					name: 'Lab',
-					start_at: Time.zone.now + 1.hour,
-					duration: 1800,
-					created_by_launch_nonce: 'nonce-owner'
-				)
-				user = User.new(uid: 'student-other', roles: 'Student', launch_nonce: 'nonce-other')
+      it 'denies non-creator students' do
+        room = Room.create!(consumer_key: 'consumer-7')
+        AppLaunch.create!(
+          nonce: 'nonce-owner',
+          params: {
+            'user_id' => 'student-owner',
+            'context_id' => 'context-7',
+            'tool_consumer_instance_guid' => 'consumer-7',
+            'resource_link_id' => 'resource-7',
+            'custom_params' => { 'custom_enable_groups_scoping' => 'false' }
+          },
+          expires_at: Time.zone.now + 1.hour
+        )
+        meeting = ScheduledMeeting.create!(
+          room: room,
+          name: 'Lab',
+          start_at: Time.zone.now + 1.hour,
+          duration: 1800,
+          created_by_launch_nonce: 'nonce-owner'
+        )
+        user = User.new(uid: 'student-other', roles: 'Student', launch_nonce: 'nonce-other')
 
-				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
-			end
+        expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
+      end
 
-			it 'denies access when app launch is missing (expired/deleted)' do
-				room = Room.create!(consumer_key: 'consumer-8')
-				meeting = ScheduledMeeting.create!(
-					room: room,
-					name: 'Old meeting',
-					start_at: Time.zone.now + 1.hour,
-					duration: 1800,
-					created_by_launch_nonce: 'nonce-expired'
-				)
-				user = User.new(uid: 'student-4', roles: 'Student', launch_nonce: 'nonce-student-4')
+      it 'denies access when app launch is missing (expired/deleted)' do
+        room = Room.create!(consumer_key: 'consumer-8')
+        meeting = ScheduledMeeting.create!(
+          room: room,
+          name: 'Old meeting',
+          start_at: Time.zone.now + 1.hour,
+          duration: 1800,
+          created_by_launch_nonce: 'nonce-expired'
+        )
+        user = User.new(uid: 'student-4', roles: 'Student', launch_nonce: 'nonce-student-4')
 
-				expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
-			end
-		end
-	end
+        expect(Abilities.can?(user, :manage_scheduled_meeting, meeting)).to be(false)
+      end
+    end
+  end
 end

--- a/themes/elos/assets/stylesheets/theme-application-elos.scss
+++ b/themes/elos/assets/stylesheets/theme-application-elos.scss
@@ -76,6 +76,12 @@ body.theme-elos {
       color: var(--color-gray-05);
     }
 
+    .item-creator {
+      font-size: 16px;
+      margin-top: 4px;
+      color: var(--color-gray-05);
+    }
+
     tr {
       margin-left: 0;
       margin-right: 0;

--- a/themes/elos/config/locales/en.yml
+++ b/themes/elos/config/locales/en.yml
@@ -124,6 +124,7 @@ en:
       entering: "Acessing..."
       title: "Classes"
   scheduled_meetings:
+    created_by: "Created by %{name}"
     destroy: "Remove"
     edit:
       action: "Edit"

--- a/themes/elos/config/locales/es.yml
+++ b/themes/elos/config/locales/es.yml
@@ -124,6 +124,7 @@ es:
       entering: "Accediendo..."
       title: "Clases"
   scheduled_meetings:
+    created_by: "Creado por %{name}"
     destroy: "Eliminar"
     edit:
       action: "Editar"

--- a/themes/elos/config/locales/pt.yml
+++ b/themes/elos/config/locales/pt.yml
@@ -124,6 +124,7 @@ pt:
       entering: "Acessando..."
       title: "Turmas"
   scheduled_meetings:
+    created_by: "Criado por %{name}"
     destroy: "Remover"
     edit:
       action: "Editar"

--- a/themes/elos/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/elos/views/shared/_scheduled_meeting_row.html.erb
@@ -4,6 +4,10 @@
     <% unless meeting.description.blank? %>
       <div class="item-description word-break"><%= meeting.description %></div>
     <% end %>
+    <% creator = meeting.creator_name %>
+    <% unless creator.blank? %>
+      <div class="item-creator"><%= t('scheduled_meetings.created_by', name: creator) %></div>
+    <% end %>
   </td>
   <td class="col-12 col-md-3 align-middle">
     <%= format_date(meeting.start_at) %>
@@ -31,7 +35,7 @@
     <% end %>
   </td>
   <td class="col-2 col-md-1 align-middle td-dropdown-opts">
-    <% if can_edit?(user, room) %>
+    <% if can_manage_scheduled_meeting?(user, meeting) %>
       <div class="dropdown dropdown-opts">
         <a href="#" class="dropdown-toggle d-flex text-decoration-none" id="dropdown-opts-<%= room.to_param %>" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <i class="icon material-icons">more_vert</i>

--- a/themes/elos/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/elos/views/shared/_scheduled_meeting_row.html.erb
@@ -4,9 +4,11 @@
     <% unless meeting.description.blank? %>
       <div class="item-description word-break"><%= meeting.description %></div>
     <% end %>
-    <% creator = meeting.creator_name %>
-    <% unless creator.blank? %>
-      <div class="item-creator"><%= t('scheduled_meetings.created_by', name: creator) %></div>
+    <% if allow_student_scheduling?(room) %>
+      <% creator = meeting.creator_name %>
+      <% unless creator.blank? %>
+        <div class="item-creator"><%= t('scheduled_meetings.created_by', name: creator) %></div>
+      <% end %>
     <% end %>
   </td>
   <td class="col-12 col-md-3 align-middle">

--- a/themes/elos/views/shared/_scheduled_meetings.html.erb
+++ b/themes/elos/views/shared/_scheduled_meetings.html.erb
@@ -10,7 +10,7 @@
     </div>
   <% end %>
 
-  <% if can_edit?(user, room) %>
+  <% if can_create_scheduled_meeting?(user, room) %>
     <div id="view-meetings" class="col-12 col-sm-12 col-md-4 col-lg-4">
   <% else %>
     <div id="view-meetings" class="col-12 col-sm-6 col-md-6 col-lg-4 offset-lg-4">
@@ -23,7 +23,7 @@
     %>
   </div>
 
-    <% if can_edit?(user, room) %>
+    <% if can_create_scheduled_meeting?(user, room) %>
     <div id="schedule-meeting" class="col-12 col-sm-12 col-md-4 col-lg-4">
       <%=
       link_to t('scheduled_meetings.new.add'),

--- a/themes/rnp/assets/stylesheets/theme-application-rnp.scss
+++ b/themes/rnp/assets/stylesheets/theme-application-rnp.scss
@@ -79,6 +79,12 @@ body.theme-rnp {
       color: var(--color-gray-05);
     }
 
+    .item-creator {
+      font-size: 16px;
+      margin-top: 4px;
+      color: var(--color-gray-05);
+    }
+
     tr {
       margin-left: 0;
       margin-right: 0;

--- a/themes/rnp/config/locales/en.yml
+++ b/themes/rnp/config/locales/en.yml
@@ -166,6 +166,7 @@ en:
       message: "Thank you for participating and until the next time."
       title: "Your session has ended"
   scheduled_meetings:
+    created_by: "Created by %{name}"
     destroy: "Remove"
     edit:
       action: "Edit"

--- a/themes/rnp/config/locales/es.yml
+++ b/themes/rnp/config/locales/es.yml
@@ -166,6 +166,7 @@ es:
       message: "Gracias por su participación y hasta luego."
       title: "Tu sesión ha terminado"
   scheduled_meetings:
+    created_by: "Creado por %{name}"
     destroy: "Eliminar"
     edit:
       action: "Editar"

--- a/themes/rnp/config/locales/pt.yml
+++ b/themes/rnp/config/locales/pt.yml
@@ -166,6 +166,7 @@ pt:
       message: "Obrigado pela sua participação e até a próxima."
       title: "Sua sessão acabou"
   scheduled_meetings:
+    created_by: "Criado por %{name}"
     destroy: "Remover"
     edit:
       action: "Editar"

--- a/themes/rnp/views/shared/_rnp_chat.html.erb
+++ b/themes/rnp/views/shared/_rnp_chat.html.erb
@@ -1,15 +1,1 @@
-<% unless Rails.application.config.rnp_chat_id.blank? %>
-  <% chat_id = Rails.application.config.rnp_chat_id %>
-  <script src="https://unpkg.com/blip-chat-widget" type="text/javascript"></script>
-  <script>
-    (function () {
-      window.onload = function () {
-        new BlipChat()
-          .withAppKey('<%= chat_id %>')
-          .withButton({"color":"#0096fa","icon":""})
-          .withCustomCommonUrl('https://rnp.chat.blip.ai/')
-          .build();
-      }
-    })();
-  </script>
-<% end %>
+<script src="https://blipbubble.apps.kloud.rnp.br/ipezinho"></script>

--- a/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
@@ -4,6 +4,10 @@
     <% unless meeting.description.blank? %>
       <div class="item-description word-break"><%= meeting.description %></div>
     <% end %>
+    <% creator = meeting.creator_name %>
+    <% unless creator.blank? %>
+      <div class="item-creator"><%= t('scheduled_meetings.created_by', name: creator) %></div>
+    <% end %>
   </td>
   <td class="col-12 col-md-3 align-middle">
     <%= format_date(meeting.start_at) %>
@@ -39,7 +43,7 @@
     <% end %>
   </td>
   <td class="col-2 col-md-1 align-middle td-dropdown-opts">
-    <% if can_edit?(user, room) %>
+    <% if can_manage_scheduled_meeting?(user, meeting) %>
       <div class="dropdown dropdown-opts">
         <a href="#" class="dropdown-toggle d-flex text-decoration-none" id="dropdown-opts-<%= room.to_param %>" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <i class="icon material-icons">more_vert</i>

--- a/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
@@ -4,9 +4,11 @@
     <% unless meeting.description.blank? %>
       <div class="item-description word-break"><%= meeting.description %></div>
     <% end %>
-    <% creator = meeting.creator_name %>
-    <% unless creator.blank? %>
-      <div class="item-creator"><%= t('scheduled_meetings.created_by', name: creator) %></div>
+    <% if allow_student_scheduling?(room) %>
+      <% creator = meeting.creator_name %>
+      <% unless creator.blank? %>
+        <div class="item-creator"><%= t('scheduled_meetings.created_by', name: creator) %></div>
+      <% end %>
     <% end %>
   </td>
   <td class="col-12 col-md-3 align-middle">

--- a/themes/rnp/views/shared/_scheduled_meetings.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meetings.html.erb
@@ -11,7 +11,7 @@
     </div>
   <% end %>
 
-  <% if can_edit?(user, room) %>
+  <% if can_create_scheduled_meeting?(user, room) %>
     <div id="view-meetings" class="col-12 col-sm-12 col-md-4 col-lg-4">
   <% else %>
     <div id="view-meetings" class="col-12 col-sm-6 col-md-6 col-lg-4 offset-lg-4">
@@ -25,7 +25,7 @@
     %>
   </div>
 
-  <% if can_edit?(user, room) %>
+  <% if can_create_scheduled_meeting?(user, room) %>
     <div id="schedule-meeting" class="col-12 col-sm-12 col-md-4 col-lg-4">
       <%=
       link_to t('scheduled_meetings.new.add'),


### PR DESCRIPTION
## Summary

- Substitui o widget Blip (`blip-chat-widget`) pelo novo script do Ipezinho em `themes/rnp/views/shared/_rnp_chat.html.erb`
- Remove a config `rnp_chat_id` (env `RNP_CHAT_ID`) de `config/application.rb`, que não é mais necessária

Espelha a mudança feita no elos-portal em mconf/elos-portal#1090 (commit `6a912c6e`).

## Test plan

- [ ] Verificar que o widget do Ipezinho aparece nas páginas do tema RNP
- [ ] Verificar que não há erros no console relacionados ao Blip
- [ ] Confirmar que a remoção de `RNP_CHAT_ID` não quebra nenhum ambiente (variável não é mais usada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)