### PR TITLE
[PRT-2623] refactor: replace Blip chat widget with Ipezinho widget

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -140,9 +140,6 @@ module BbbAppRooms
     config.filesender_service_url       = Mconf::Env.fetch('MCONF_FILESENDER_SERVICE_URL')
     config.filesender_client_secret     = Mconf::Env.fetch('MCONF_FILESENDER_CLIENT_SECRET')
 
-    # RNP CHAT
-    config.rnp_chat_id = Mconf::Env.fetch('RNP_CHAT_ID', '')
-
     # Moodle API
     config.moodle_api_timeout = Mconf::Env.fetch_int('MCONF_MOODLE_API_TIMEOUT', 5)
     config.moodle_recurring_events_month_period = Mconf::Env.fetch_int('MCONF_MOODLE_RECURRING_EVENTS_MONTH_PERIOD', 12)

--- a/themes/rnp/views/shared/_rnp_chat.html.erb
+++ b/themes/rnp/views/shared/_rnp_chat.html.erb
@@ -1,15 +1,1 @@
-<% unless Rails.application.config.rnp_chat_id.blank? %>
-  <% chat_id = Rails.application.config.rnp_chat_id %>
-  <script src="https://unpkg.com/blip-chat-widget" type="text/javascript"></script>
-  <script>
-    (function () {
-      window.onload = function () {
-        new BlipChat()
-          .withAppKey('<%= chat_id %>')
-          .withButton({"color":"#0096fa","icon":""})
-          .withCustomCommonUrl('https://rnp.chat.blip.ai/')
-          .build();
-      }
-    })();
-  </script>
-<% end %>
+<script src="https://blipbubble.apps.kloud.rnp.br/ipezinho"></script>


### PR DESCRIPTION
## Summary
- Replace Blip chat widget with Ipezinho widget in RNP theme
- Remove `BlipChat` initialization script and `rnp_chat_id` config
- Remove `RNP_CHAT_ID` environment variable usage

Replicates the same change made for elos-portal in mconf/elos-portal#1090 (commit `6a912c6e`).

Closes: https://www.notion.so/34333ac02c6a8157b066ea3603e6a4f4

🤖 Generated with [Claude Code](https://claude.com/claude-code)