### PR TITLE
[PRT-2551] chore: add follow redirects loop with validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,7 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails'
 gem 'faraday'
 gem 'faraday-multipart'
+gem 'faraday-follow_redirects'
 gem 'repost', '~> 0.4.2'
 
 # BigBlueButton API

--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,6 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails'
 gem 'faraday'
 gem 'faraday-multipart'
-gem 'faraday-follow_redirects'
 gem 'repost', '~> 0.4.2'
 
 # BigBlueButton API

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,8 @@ GEM
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
     faraday-net_http (3.0.2)
@@ -587,6 +589,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faraday
+  faraday-follow_redirects
   faraday-multipart
   font-awesome-rails
   friendly_id (~> 5.4.0)

--- a/lib/moodle.rb
+++ b/lib/moodle.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'faraday'
+require 'faraday/follow_redirects'
 require 'cgi'
 
 module Moodle
@@ -588,6 +589,7 @@ module Moodle
 
           conn = Faraday.new(url: host_url, **options) do |config|
             config.response :json
+            config.response :follow_redirects, limit: 1
             config.response :raise_error
             config.adapter :net_http
           end

--- a/lib/moodle.rb
+++ b/lib/moodle.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'faraday'
-require 'faraday/follow_redirects'
 require 'cgi'
 
 module Moodle
@@ -576,6 +575,7 @@ module Moodle
     end
 
     MAX_RETRIES = 3
+    MAX_REDIRECTS = 3
 
     def self.post(host_url, params)
       retries ||= 0
@@ -587,17 +587,41 @@ module Moodle
             params: params
           }
 
-          conn = Faraday.new(url: host_url, **options) do |config|
-            config.response :json
-            config.response :follow_redirects, limit: 1
-            config.response :raise_error
-            config.adapter :net_http
+          start_time = Time.now
+          current_url = host_url
+          redirect_count = 0
+          res = nil
+
+          loop do
+            conn = Faraday.new(url: current_url, **options) do |config|
+              config.response :json
+              config.response :raise_error
+              config.adapter :net_http
+            end
+
+            res = conn.post(current_url)
+            break unless (300...400).cover?(res.status)
+
+            redirect_count += 1
+            raise RequestError, "Too many redirects" if redirect_count > MAX_REDIRECTS
+
+            location = res.headers['location']
+            raise RequestError, "Redirect missing Location header" if location.blank?
+
+            original_uri = URI.parse(current_url)
+            redirect_uri = URI.parse(location)
+
+            raise RequestError, "Redirect to different host" \
+              unless original_uri.host == redirect_uri.host
+
+            raise RequestError, "Unsafe redirect scheme change" \
+              unless original_uri.scheme == redirect_uri.scheme ||
+                     (original_uri.scheme == 'http' && redirect_uri.scheme == 'https')
+
+            current_url = location
           end
 
-          start_time = Time.now
-          res = conn.post(host_url)
           duration = Time.now - start_time
-
           result = res.body.is_a?(Hash) ? res.body.merge({"duration" => duration}) :
                                           { "body" => res.body, "duration" => duration }
 


### PR DESCRIPTION
This PR handles HTTP redirects (302) in Faraday calls. Previously, calls returned a 302 status with an empty body, causing silent integration failures since the redirect was not being followed to the HTTPS URL provided in the location header.

**Changes:**
Added redirect loop with explicit validation:

More than 3 redirects → RequestError
Missing Location header → RequestError
Host differs from the original → RequestError
Scheme change other than http → https → RequestError
http → https on the same host → allowed and followed normally
