### PR TITLE
[PRT-2570] feature: track last meeting date for scheduled meetings

### DIFF
--- a/db/migrate/20260416193450_add_last_meeting_date_to_scheduled_meetings.rb
+++ b/db/migrate/20260416193450_add_last_meeting_date_to_scheduled_meetings.rb
@@ -1,0 +1,5 @@
+class AddLastMeetingDateToScheduledMeetings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :scheduled_meetings, :last_meeting_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_23_182237) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_16_193450) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -161,6 +161,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_23_182237) do
     t.string "moodle_group_name"
     t.boolean "mark_moodle_attendance"
     t.boolean "mark_brightspace_attendance", default: false, null: false
+    t.datetime "last_meeting_date"
     t.index ["created_by_launch_nonce"], name: "index_scheduled_meetings_on_created_by_launch_nonce"
     t.index ["hash_id"], name: "index_scheduled_meetings_on_hash_id", unique: true
     t.index ["repeat"], name: "index_scheduled_meetings_on_repeat"

--- a/lib/bbb_api.rb
+++ b/lib/bbb_api.rb
@@ -56,6 +56,7 @@ module BbbApi
           meeting_id,
           options
         )
+        scheduled_meeting.update_column(:last_meeting_date, Time.current.utc)
       rescue BigBlueButton::BigBlueButtonException => e
         if ['simultaneousMeetingsLimitReachedForSecret', 'simultaneousMeetingsLimitReachedForInstitution'].include? e.key.to_s
           return { can_join?: false, messageKey: e.key.to_s }


### PR DESCRIPTION
This PR adds the `last_meeting_date` to `scheduled_meetings` to track which scheduled meetings are actively being used by users.

## Changes
- Added `last_meeting_date` column to `scheduled_meetings`.
- Updated `bbb_api.rb` to record `Time.current.utc` when a user joins a room.