### PR TITLE
[PRT-2628] feat: changed join button style

### DIFF
--- a/themes/rnp/assets/stylesheets/_definitions-rnp.scss
+++ b/themes/rnp/assets/stylesheets/_definitions-rnp.scss
@@ -41,7 +41,9 @@ $vars: (
   --line-height: 1.5,
   --border-color: #DEE2E6,
   --z-index-toast: 999,
-  --background-placeholder-loading: #ced4da
+  --background-placeholder-loading: #ced4da,
+  --join-room-btn-color: #F18700,
+  --join-room-btn-hover-color: #D76C02
 );
 // variables in this map can be used as in:
 // map-get($vars, '--color-main')

--- a/themes/rnp/assets/stylesheets/theme-application-rnp.scss
+++ b/themes/rnp/assets/stylesheets/theme-application-rnp.scss
@@ -109,17 +109,26 @@ body.theme-rnp {
   }
 
   .join-room-btn {
-    height: blocks(5);
-    width: blocks(5);
-    border-radius: 50%;
-    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 
-    .icon {
-      margin: 0;
-      font-size: 33px;
-      width: 100%;
+    height: 40px;
+    padding: 8px 32px;
+    border-color: var(--join-room-btn-color);
+    background-color: var(--join-room-btn-color);
+
+    .btn-text {
+      color: var(--color-white);
+      font-weight: 500;
+      font-size: 16px;
       line-height: 1;
-      padding: 3px 0px 0 1px;
+      text-transform: none;
+    }
+
+    &:hover {
+      background-color: var(--join-room-btn-hover-color) !important;
+      text-decoration: none;
     }
 
     &.loading {
@@ -880,4 +889,8 @@ body.theme-rnp {
     font-size: var(--m-font-fields);
     cursor: pointer;
   }
+}
+
+.tooltip .tooltip-inner {
+  font-family: var(--font-family)
 }

--- a/themes/rnp/config/locales/en.yml
+++ b/themes/rnp/config/locales/en.yml
@@ -185,6 +185,7 @@ en:
       footnote: "Dates shown in the time zone: %{zone}"
     title: "Scheduled sessions"
     title_with_group: "Scheduled sessions | Group: %{group_name}"
+    join_tooltip: "Join session"
     wait:
       retry: "Join"
   open_app_modal:

--- a/themes/rnp/config/locales/es.yml
+++ b/themes/rnp/config/locales/es.yml
@@ -185,6 +185,7 @@ es:
       footnote: "Fechas mostradas en la zona horaria: %{zone}"
     title: "Sesiones programadas"
     title_with_group: "Sesiones programadas | Grupo: %{group_name}"
+    join_tooltip: "Entrar en la sesión"
     wait:
       retry: "Entrar"
   open_app_modal:

--- a/themes/rnp/config/locales/pt.yml
+++ b/themes/rnp/config/locales/pt.yml
@@ -185,6 +185,7 @@ pt:
       footnote: "Datas exibidas no fuso horário: %{zone}"
     title: "Sessões agendadas"
     title_with_group: "Sessões agendadas | Grupo: %{group_name}"
+    join_tooltip: "Entrar na sessão"
     wait:
       retry: "Entrar"
   open_app_modal:

--- a/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
@@ -23,20 +23,20 @@
     <% can_join = !(wait_for_mod?(meeting, user)) %>
     <% if can_join && device_type? != 'desktop' %>
       <%= form_with url: join_room_scheduled_meeting_path(room, meeting), id: "join-form-#{meeting.hash_id}" do |form| %>
-        <span data-toggle="tooltip" data-placement="top" title="Entrar na sessão">
+        <span data-toggle="tooltip" data-placement="top" title="<%= t('scheduled_meetings.join_tooltip') %>">
           <button class="btn btn-primary join-room-btn" type="button" data-bs-toggle="offcanvas" data-bs-target=<%="#offcanvasBottom-#{meeting.hash_id}"%> aria-controls="offcanvasBottom">
-            <span>Entrar</span>
+            <span><%= t('scheduled_meetings.wait.retry') %></span>
           </button>
         </span>
         <%= render "shared/app_offcanvas", room: room, meeting: meeting, target_blank: !(browser.safari? || browser.safari_webapp_mode?) %>
       <% end %>
     <% elsif browser.safari? || browser.safari_webapp_mode? %>
-      <%= link_to join_room_scheduled_meeting_url(room, meeting, no_auto_join: true), class: "btn btn-primary join-room-btn", data: { 'tracking-id': 'lti-join-session', 'institution-guid': "#{@institution_guid}", toggle: 'tooltip', placement: 'top' }, title: 'Entrar na sessão' do %>
-        <span>Entrar</span>
+      <%= link_to join_room_scheduled_meeting_url(room, meeting, no_auto_join: true), class: "btn btn-primary join-room-btn", data: { 'tracking-id': 'lti-join-session', 'institution-guid': "#{@institution_guid}", toggle: 'tooltip', placement: 'top' }, title: t('scheduled_meetings.join_tooltip') do %>
+        <span><%= t('scheduled_meetings.wait.retry') %></span>
       <% end %>
     <% else %>
-      <%= link_to join_room_scheduled_meeting_url(room, meeting, no_auto_join: true), class: "btn btn-primary join-room-btn create-session-token", data: { 'tracking-id': 'lti-join-session', 'institution-guid': "#{@institution_guid}", toggle: 'tooltip', placement: 'top' }, title: 'Entrar na sessão', target: '_blank' do %>
-        <span>Entrar</span>
+      <%= link_to join_room_scheduled_meeting_url(room, meeting, no_auto_join: true), class: "btn btn-primary join-room-btn create-session-token", data: { 'tracking-id': 'lti-join-session', 'institution-guid': "#{@institution_guid}", toggle: 'tooltip', placement: 'top' }, title: t('scheduled_meetings.join_tooltip'), target: '_blank' do %>
+        <span><%= t('scheduled_meetings.wait.retry') %></span>
       <% end %>
     <% end %>
   </td>

--- a/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
@@ -14,27 +14,29 @@
       </span>
     <% end %>
   </td>
-  <td class="col-12 col-md-2 align-middle">
+  <td class="col-12 col-md-1 align-middle">
     <% if meeting.duration > 0 %>
       <%= duration_in_hours_and_minutes(meeting.duration).capitalize %>
     <% end %>
   </td>
-  <td class="col-12 col-md-1 align-middle">
+  <td class="col-12 col-md-2 align-middle">
     <% can_join = !(wait_for_mod?(meeting, user)) %>
     <% if can_join && device_type? != 'desktop' %>
       <%= form_with url: join_room_scheduled_meeting_path(room, meeting), id: "join-form-#{meeting.hash_id}" do |form| %>
-        <button class="btn btn-primary join-room-btn" type="button" data-bs-toggle="offcanvas" data-bs-target=<%="#offcanvasBottom-#{meeting.hash_id}"%> aria-controls="offcanvasBottom">
-          <i class="icon material-icons">play_arrow</i>
-        </button>
+        <span data-toggle="tooltip" data-placement="top" title="Entrar na sessão">
+          <button class="btn btn-primary join-room-btn" type="button" data-bs-toggle="offcanvas" data-bs-target=<%="#offcanvasBottom-#{meeting.hash_id}"%> aria-controls="offcanvasBottom">
+            <span>Entrar</span>
+          </button>
+        </span>
         <%= render "shared/app_offcanvas", room: room, meeting: meeting, target_blank: !(browser.safari? || browser.safari_webapp_mode?) %>
       <% end %>
     <% elsif browser.safari? || browser.safari_webapp_mode? %>
-      <%= link_to join_room_scheduled_meeting_url(room, meeting, no_auto_join: true), class: "btn btn-primary join-room-btn", data: { 'tracking-id': 'lti-join-session', 'institution-guid': "#{@institution_guid}" } do %>
-        <i class="icon material-icons">play_arrow</i>
+      <%= link_to join_room_scheduled_meeting_url(room, meeting, no_auto_join: true), class: "btn btn-primary join-room-btn", data: { 'tracking-id': 'lti-join-session', 'institution-guid': "#{@institution_guid}", toggle: 'tooltip', placement: 'top' }, title: 'Entrar na sessão' do %>
+        <span>Entrar</span>
       <% end %>
     <% else %>
-      <%= link_to join_room_scheduled_meeting_url(room, meeting, no_auto_join: true), class: "btn btn-primary join-room-btn create-session-token", data: { 'tracking-id': 'lti-join-session', 'institution-guid': "#{@institution_guid}" }, target: '_blank' do %>
-        <i class="icon material-icons">play_arrow</i>
+      <%= link_to join_room_scheduled_meeting_url(room, meeting, no_auto_join: true), class: "btn btn-primary join-room-btn create-session-token", data: { 'tracking-id': 'lti-join-session', 'institution-guid': "#{@institution_guid}", toggle: 'tooltip', placement: 'top' }, title: 'Entrar na sessão', target: '_blank' do %>
+        <span>Entrar</span>
       <% end %>
     <% end %>
   </td>


### PR DESCRIPTION
This PR changes join button style and adds informative tooltip.

**Visual Changes:**

Desktop view:
<img width="1367" height="579" alt="Captura de tela de 2026-05-11 16-38-10" src="https://github.com/user-attachments/assets/3e3f3738-3c92-4fa7-a169-59961c331aaf" />

Mobile view: 
<img width="758" height="920" alt="Captura de tela de 2026-05-11 16-38-20" src="https://github.com/user-attachments/assets/8ab7d9f4-9b0c-4772-934e-9b457b2b0861" />
