### PR TITLE
[PRT-2636] fix: add LTI data to exception notification emails

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -262,8 +262,8 @@ class ApplicationController < ActionController::Base
             tool_consumer: @app_launch&.params&.[]('tool_consumer_instance_name'),
             current_user: {
               id: @user&.uid,
-              name: @user&.full_name,
-              email: @user&.email,
+              name: @user&.full_name || @app_launch&.omniauth_auth.dig('bbbltibroker', 'info', 'full_name'),
+              email: @user&.email || @app_launch&.omniauth_auth.dig('bbbltibroker', 'info', 'email'),
             }
           }
         )

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -262,8 +262,8 @@ class ApplicationController < ActionController::Base
             tool_consumer: @app_launch&.params&.[]('tool_consumer_instance_name'),
             current_user: {
               id: @user&.uid,
-              name: @user&.full_name || @app_launch&.omniauth_auth.dig('bbbltibroker', 'info', 'full_name'),
-              email: @user&.email || @app_launch&.omniauth_auth.dig('bbbltibroker', 'info', 'email'),
+              name: @user&.full_name || @app_launch&.omniauth_auth&.dig('bbbltibroker', 'info', 'full_name'),
+              email: @user&.email || @app_launch&.omniauth_auth&.dig('bbbltibroker', 'info', 'email'),
             }
           }
         )

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -255,7 +255,6 @@ class ApplicationController < ActionController::Base
       begin
         ExceptionNotifier.notify_exception(
           exception,
-          env: request.env,
           data: {
             consumer_key: @app_launch&.consumer_key,
             launch_nonce: @app_launch&.nonce,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -253,7 +253,21 @@ class ApplicationController < ActionController::Base
 
     if Mconf::Env.fetch_boolean('EXCEPTION_NOTIFICATIONS_ENABLED', true) && exception
       begin
-        ExceptionNotifier.notify_exception(exception)
+        ExceptionNotifier.notify_exception(
+          exception,
+          env: request.env,
+          data: {
+            consumer_key: @app_launch&.consumer_key,
+            launch_nonce: @app_launch&.nonce,
+            moodle_url: @app_launch&.params&.[]('launch_presentation_return_url'),
+            tool_consumer: @app_launch&.params&.[]('tool_consumer_instance_name'),
+            current_user: {
+              id: @user&.uid,
+              name: @user&.full_name,
+              email: @user&.email,
+            }
+          }
+        )
       rescue => notify_err
         Rails.logger.warn "ExceptionNotifier failed: #{notify_err.class}: #{notify_err.message}"
       end


### PR DESCRIPTION
This PR fixes empty data section in exception notification emails. Pass request.env and relevant LTI launch data (consumer key, nonce, Moodle URL, tool consumer name, and current user info) to ExceptionNotifier so error emails include actionable context instead of empty sections.