### PR TITLE
[PRT-2578] Add character limit for scheduled session names

### DIFF
--- a/app/controllers/scheduled_meetings_controller.rb
+++ b/app/controllers/scheduled_meetings_controller.rb
@@ -317,7 +317,10 @@ class ScheduledMeetingsController < ApplicationController
           return
         end
 
-        opts[:meeting_name] = "#{@scheduled_meeting.name} - #{group_name}"
+        group_suffix = " - #{group_name}"
+        name_budget = ScheduledMeeting::NAME_MAX_LENGTH - group_suffix.length
+        truncated_name = @scheduled_meeting.name.truncate([name_budget, 0].max)
+        opts[:meeting_name] = "#{truncated_name}#{group_suffix}"
       end
 
       if @room.can_mark_moodle_attendance && @scheduled_meeting.mark_moodle_attendance

--- a/app/models/scheduled_meeting.rb
+++ b/app/models/scheduled_meeting.rb
@@ -2,6 +2,7 @@ class ScheduledMeeting < ApplicationRecord
   include Friendlyable
 
   paginates_per 10
+  NAME_MAX_LENGTH = 256
 
   REPEAT_OPTIONS = {
     weekly: 1.week,
@@ -16,7 +17,12 @@ class ScheduledMeeting < ApplicationRecord
           inverse_of: :scheduled_meeting
 
   validates :room, presence: true
-  validates :name, presence: true
+  validates :name, presence: true, length: {
+    maximum: ScheduledMeeting::NAME_MAX_LENGTH,
+    message: ->(object, data) {
+      I18n.t('default.scheduled_meeting.error.name_max_length', max: ScheduledMeeting::NAME_MAX_LENGTH)
+    }
+  }
   validates :start_at, presence: true
   validates :duration, presence: true
   validates :repeat, inclusion: { in: [nil] + ScheduledMeeting::REPEAT_OPTIONS.keys }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,7 +120,7 @@ en:
         simultaneousMeetingsLimitReachedForSecret: "Maximum limit of simultaneous meetings reached"
         simultaneousMeetingsLimitReachedForInstitution: "Maximum limit of simultaneous meetings of the institution reached"
         simultaneousParticipantsLimitReachedForSecret: "Maximum limit of simultaneous participants reached"
-        name_max_length: "The session name has reached the maximum of %{max} characters"
+        name_max_length: "The session name can have at most %{max} characters"
       external:
         ended:        "This session has already ended."
         first_name:   "First name"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,6 +120,7 @@ en:
         simultaneousMeetingsLimitReachedForSecret: "Maximum limit of simultaneous meetings reached"
         simultaneousMeetingsLimitReachedForInstitution: "Maximum limit of simultaneous meetings of the institution reached"
         simultaneousParticipantsLimitReachedForSecret: "Maximum limit of simultaneous participants reached"
+        name_max_length: "The session name has reached the maximum of %{max} characters"
       external:
         ended:        "This session has already ended."
         first_name:   "First name"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -89,7 +89,7 @@ es:
         simultaneousMeetingsLimitReachedForSecret: "Límite máximo de reuniones simultáneas alcanzado"
         simultaneousMeetingsLimitReachedForInstitution: "Límite máximo de reuniones simultáneas de la institución alcanzado"
         simultaneousParticipantsLimitReachedForSecret: "Límite máximo de participantes simultáneos alcanzado"
-        name_max_length: "El nombre alcanzó el máximo de %{max} caracteres"
+        name_max_length: "El nombre de la sesión puede tener como máximo %{max} caracteres"
       external:
         ended:        "Esta sesión ya terminó."
         first_name:   "Primer nombre"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -89,6 +89,7 @@ es:
         simultaneousMeetingsLimitReachedForSecret: "Límite máximo de reuniones simultáneas alcanzado"
         simultaneousMeetingsLimitReachedForInstitution: "Límite máximo de reuniones simultáneas de la institución alcanzado"
         simultaneousParticipantsLimitReachedForSecret: "Límite máximo de participantes simultáneos alcanzado"
+        name_max_length: "El nombre alcanzó el máximo de %{max} caracteres"
       external:
         ended:        "Esta sesión ya terminó."
         first_name:   "Primer nombre"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -89,6 +89,7 @@ pt:
         simultaneousMeetingsLimitReachedForSecret: "Limite máximo de reuniões simultâneas atingido"
         simultaneousMeetingsLimitReachedForInstitution: "Limite máximo de reuniões simultâneas da instituição atingido"
         simultaneousParticipantsLimitReachedForSecret: "Limite máximo de participantes simultâneos atingido"
+        name_max_length: "O nome da sessão atingiu o máximo de %{max} caracteres"
       external:
         ended:        "Esta sessão já encerrou."
         first_name:   "Primeiro nome"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -89,7 +89,7 @@ pt:
         simultaneousMeetingsLimitReachedForSecret: "Limite máximo de reuniões simultâneas atingido"
         simultaneousMeetingsLimitReachedForInstitution: "Limite máximo de reuniões simultâneas da instituição atingido"
         simultaneousParticipantsLimitReachedForSecret: "Limite máximo de participantes simultâneos atingido"
-        name_max_length: "O nome da sessão atingiu o máximo de %{max} caracteres"
+        name_max_length: "O nome da sessão pode ter no máximo %{max} caracteres"
       external:
         ended:        "Esta sessão já encerrou."
         first_name:   "Primeiro nome"

--- a/lib/bbb_api.rb
+++ b/lib/bbb_api.rb
@@ -46,7 +46,8 @@ module BbbApi
     logout_url = opts[:logout_url] || autoclose_url
 
     unless bbb(room).is_meeting_running?(meeting_id)
-      meeting_name = opts[:meeting_name] || scheduled_meeting.meeting_name
+      meeting_name = (opts[:meeting_name] || scheduled_meeting.meeting_name)
+        .truncate(ScheduledMeeting::NAME_MAX_LENGTH)
 
       begin
         options = scheduled_meeting.create_options(user)

--- a/themes/elos/assets/javascripts/schedule-elos.js
+++ b/themes/elos/assets/javascripts/schedule-elos.js
@@ -11,7 +11,7 @@ $(document).on('turbolinks:load', function(){
     if (nameField) {
       var nameMaxLength = parseInt(nameField.getAttribute('maxlength'));
       nameField.addEventListener('input', function() {
-        if (this.value.length >= nameMaxLength) {
+        if (this.value.length > nameMaxLength) {
           this.setCustomValidity(I18n.t('default.scheduled_meeting.error.name_max_length', { max: nameMaxLength }));
           this.reportValidity();
         } else if (this.validity.customError) {

--- a/themes/elos/assets/javascripts/schedule-elos.js
+++ b/themes/elos/assets/javascripts/schedule-elos.js
@@ -7,6 +7,23 @@ $(document).on('turbolinks:load', function(){
     var datePicker = document.getElementsByName("scheduled_meeting[date]")[0];
     datePicker?.addEventListener('change', checkTime);
 
+    var nameField = document.querySelector('input[name="scheduled_meeting[name]"]');
+    if (nameField) {
+      var nameMaxLength = parseInt(nameField.getAttribute('maxlength'));
+      nameField.addEventListener('input', function() {
+        if (this.value.length >= nameMaxLength) {
+          this.setCustomValidity(I18n.t('default.scheduled_meeting.error.name_max_length', { max: nameMaxLength }));
+          this.reportValidity();
+        } else if (this.validity.customError) {
+          this.setCustomValidity('');
+        }
+      });
+      var nameForm = nameField.closest('form');
+      nameForm?.querySelector('[type="submit"]')?.addEventListener('click', function() {
+        if (nameField.value.length <= nameMaxLength) nameField.setCustomValidity('');
+      });
+    }
+
     function controlCustomDuration(e) {
       let valueSelectDuration = e.target.value;
       valueSelectDuration == 0 ? contentCustomDuration.classList.add('d-block') :

--- a/themes/elos/views/scheduled_meetings/_form.html.erb
+++ b/themes/elos/views/scheduled_meetings/_form.html.erb
@@ -6,9 +6,15 @@
   <% end %>
 
   <div class="form-row">
+    <% name_error = @scheduled_meeting.errors[:name].any? %>
     <div class="form-group col-12">
       <%= form.label :name %>
-      <%= form.text_field :name, required: true, minlength: 2, maxlength: 256, class: "form-control", autofocus: true %>
+      <% if name_error %> <div class="field_with_errors"> <% end %>
+        <%= form.text_field :name, required: true, minlength: 2, maxlength: ScheduledMeeting::NAME_MAX_LENGTH, class: "form-control", autofocus: true %>
+      <% if name_error %> </div> <% end %>
+      <% if name_error %>
+        <p class="error-description"><%= @scheduled_meeting.errors[:name].first %></p>
+      <% end %>
     </div>
   </div>
 

--- a/themes/elos/views/scheduled_meetings/_form.html.erb
+++ b/themes/elos/views/scheduled_meetings/_form.html.erb
@@ -8,7 +8,7 @@
   <div class="form-row">
     <div class="form-group col-12">
       <%= form.label :name %>
-      <%= form.text_field :name, required: true, minlength: 2, class: "form-control", autofocus: true %>
+      <%= form.text_field :name, required: true, minlength: 2, maxlength: 256, class: "form-control", autofocus: true %>
     </div>
   </div>
 

--- a/themes/rnp/assets/javascripts/schedule-rnp.js
+++ b/themes/rnp/assets/javascripts/schedule-rnp.js
@@ -11,7 +11,7 @@ $(document).on('turbolinks:load', function(){
     if (nameField) {
       var nameMaxLength = parseInt(nameField.getAttribute('maxlength'));
       nameField.addEventListener('input', function() {
-        if (this.value.length >= nameMaxLength) {
+        if (this.value.length > nameMaxLength) {
           this.setCustomValidity(I18n.t('default.scheduled_meeting.error.name_max_length', { max: nameMaxLength }));
           this.reportValidity();
         } else if (this.validity.customError) {

--- a/themes/rnp/assets/javascripts/schedule-rnp.js
+++ b/themes/rnp/assets/javascripts/schedule-rnp.js
@@ -7,6 +7,23 @@ $(document).on('turbolinks:load', function(){
     var datePicker = document.getElementsByName("scheduled_meeting[date]")[0];
     datePicker?.addEventListener('change', checkTime);
 
+    var nameField = document.querySelector('input[name="scheduled_meeting[name]"]');
+    if (nameField) {
+      var nameMaxLength = parseInt(nameField.getAttribute('maxlength'));
+      nameField.addEventListener('input', function() {
+        if (this.value.length >= nameMaxLength) {
+          this.setCustomValidity(I18n.t('default.scheduled_meeting.error.name_max_length', { max: nameMaxLength }));
+          this.reportValidity();
+        } else if (this.validity.customError) {
+          this.setCustomValidity('');
+        }
+      });
+      var nameForm = nameField.closest('form');
+      nameForm?.querySelector('[type="submit"]')?.addEventListener('click', function() {
+        if (nameField.value.length <= nameMaxLength) nameField.setCustomValidity('');
+      });
+    }
+
     function controlCustomDuration(e) {
       let valueSelectDuration = e.target.value;
       valueSelectDuration == 0 ? contentCustomDuration.classList.add('d-block') :

--- a/themes/rnp/views/scheduled_meetings/_form.html.erb
+++ b/themes/rnp/views/scheduled_meetings/_form.html.erb
@@ -6,9 +6,15 @@
   <% end %>
 
   <div class="form-row">
+    <% name_error = @scheduled_meeting.errors[:name].any? %>
     <div class="form-group col-12">
       <%= form.label :name %>
-      <%= form.text_field :name, required: true, minlength: 2, maxlength: 256, class: "form-control", autofocus: true %>
+      <% if name_error %> <div class="field_with_errors"> <% end %>
+        <%= form.text_field :name, required: true, minlength: 2, maxlength: ScheduledMeeting::NAME_MAX_LENGTH, class: "form-control", autofocus: true %>
+      <% if name_error %> </div> <% end %>
+      <% if name_error %>
+        <p class="error-description"><%= @scheduled_meeting.errors[:name].first %></p>
+      <% end %>
     </div>
   </div>
 

--- a/themes/rnp/views/scheduled_meetings/_form.html.erb
+++ b/themes/rnp/views/scheduled_meetings/_form.html.erb
@@ -8,7 +8,7 @@
   <div class="form-row">
     <div class="form-group col-12">
       <%= form.label :name %>
-      <%= form.text_field :name, required: true, minlength: 2, class: "form-control", autofocus: true %>
+      <%= form.text_field :name, required: true, minlength: 2, maxlength: 256, class: "form-control", autofocus: true %>
     </div>
   </div>
 


### PR DESCRIPTION
This PR adds a 256-character limit for scheduled session names. It prevents over-limit names from being saved, gives visual feedback both while typing and on save, and ensures existing sessions with long names still work when joining a BBB meeting. All changes is applied to both elos and rnp themes

The solution includes:
- NAME_MAX_LENGTH constant used across the model, form and truncation
- backend validation on the ScheduledMeeting model, blocking over-limit names from being saved 
- maxlength attribute and real-time feedback on name input via native HTML validation with error-state cleanup on correct/submit
- error state on the field when saving fails (field_with_errors + message), following the existing pattern
- truncation with "..." before create_meeting, so legacy sessions with long names still work when joined
- internationalization support in pt, en and es

**Visual Changes:**

<img width="1487" height="620" alt="criar_tooltip_20-10_bbb-app-rooms_13-07" src="https://github.com/user-attachments/assets/293a01a8-80b2-4235-8ece-6227ba1f2f79" />
<img width="1487" height="620" alt="editar_msg_20-11_bbb-app-rooms_13-07" src="https://github.com/user-attachments/assets/dcc971e1-18fe-4176-9fcf-31624e8c0041" />
<img width="1487" height="620" alt="truncamento_teste_20-07_bbb-app-rooms_13-07" src="https://github.com/user-attachments/assets/33b056ae-0e70-4a7e-9bab-00916e752ba9" />