### PR TITLE
[PRT-2681] Feat: AI artifacts announcements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,7 @@ MCONF_ADOPT_WEBSITE_CODE=adopt-website-code
 MCONF_LLM_API_URL=
 # TTL in seconds for AI artifact cache entries (pending/error status). Default: 10800 (3 hours)
 MCONF_LLM_ARTIFACT_CACHE_TTL=10800
+MCONF_AI_ARTIFACTS_RELEASE_DATE=2026-06-22
 
 ### Mconf Data API
 # URL (with port)

--- a/app/helpers/icons_helper.rb
+++ b/app/helpers/icons_helper.rb
@@ -87,6 +87,10 @@ module IconsHelper
     material_icon_constructor "analytics", "icon material-icons icon-analytics", options
   end
 
+  def icon_arrow_right(options={})
+    material_icon_constructor "chevron_right", "icon material-icons icon-chevron-right", options
+  end
+
   def icon_video_library(options={})
     material_icon_constructor "video_library", "icon material-symbols-rounded icon-video-library", options
   end
@@ -108,7 +112,7 @@ module IconsHelper
   end
 
   def icon_not_check(options={})
-    material_icon_constructor "close", "icon material-symbols-rounded icon_not_check", options
+    material_icon_constructor "close", "icon material-symbols-rounded icon-not-check", options
   end
 
   def icon_upload_image(options={})

--- a/config/application.rb
+++ b/config/application.rb
@@ -151,6 +151,12 @@ module BbbAppRooms
     # Mconf LLM API
     config.llm_api_url = Mconf::Env.fetch('MCONF_LLM_API_URL', '')
     config.llm_artifact_cache_ttl = Mconf::Env.fetch_int('MCONF_LLM_ARTIFACT_CACHE_TTL', 10800)
+    config.ai_artifacts_release_date = begin
+      date_str = Mconf::Env.fetch('MCONF_AI_ARTIFACTS_RELEASE_DATE')
+      date_str.present? ? Date.iso8601(date_str) : ''
+    rescue ArgumentError, TypeError
+      nil
+    end
 
     ### Bigbluebutton API
     config.bigbluebutton_endpoint = Mconf::Env.fetch('BIGBLUEBUTTON_ENDPOINT',

--- a/themes/elos/assets/javascripts/theme-application-elos.js
+++ b/themes/elos/assets/javascripts/theme-application-elos.js
@@ -153,4 +153,8 @@ $(document).on('turbolinks:load', function(){
     trackingId = `lti-${prefix}-meeting-recurrence-${value ? value : 'does_not_repeat'}`;
     e.target.setAttribute("data-tracking-id", trackingId);
   });
+
+  $('#ai-features-banner .close, #ai-features-banner .btn').on('click', function() {
+    document.cookie = 'ai_features_banner_dismissed=1; path=/; SameSite=Lax';
+  });
 });

--- a/themes/elos/assets/stylesheets/theme-application-elos.scss
+++ b/themes/elos/assets/stylesheets/theme-application-elos.scss
@@ -358,6 +358,119 @@ body.theme-elos {
       padding: blocks(2) $block;
       margin-right: blocks(2);
     }
+
+    #view-meetings {
+      position: relative;
+    }
+
+    .ai-features-banner {
+      position: absolute;
+      top: calc(100% + 10px);
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 100;
+      background-color: #EAFAFB;
+      border-radius: 12px;
+      filter: drop-shadow(4px 4px 4px rgba(32, 32, 32, 0.2));
+      padding: 24px;
+      width: 324px;
+
+      &::before {
+        content: '';
+        position: absolute;
+        top: -8px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 0;
+        height: 0;
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        border-bottom: 8px solid #ebf7ff;
+      }
+
+      .content {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+
+        p {
+          text-align: left;
+        }
+      }
+
+      .icon-title {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 2px;
+
+        img {
+          filter: brightness(0) saturate(100%) invert(45%) sepia(100%) saturate(500%) hue-rotate(148deg) brightness(85%);
+        }
+      }
+
+      .icon {
+        width: 24px;
+        height: 24px;
+      }
+
+      .title {
+        font-size: 18px;
+        font-weight: 700;
+        color: #008C95;
+        line-height: normal;
+        margin: 0;
+      }
+
+      .description {
+        font-size: 16px;
+        color: #202020;
+        margin: 0;
+        line-height: normal;
+      }
+
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        background-color: #008C95;
+        color: var(--color-white);
+        border-radius: 8px;
+        padding: 4px 16px 4px 24px;
+        font-weight: 600;
+        font-size: 16px;
+        text-decoration: none;
+        width: fit-content;
+        max-width: none;
+        margin: 0 auto;
+
+        &:hover {
+          background-color: #073d85;
+          color: var(--color-white);
+          text-decoration: none;
+        }
+
+        .icon {
+          font-size: 24px;
+        }
+      }
+
+      .close {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--color-black);
+
+        .icon {
+          font-size: 16px;
+        }
+      }
+    }
   }
 
   #meetings-list {

--- a/themes/elos/assets/stylesheets/theme-application-elos.scss
+++ b/themes/elos/assets/stylesheets/theme-application-elos.scss
@@ -445,7 +445,7 @@ body.theme-elos {
         margin: 0 auto;
 
         &:hover {
-          background-color: #073d85;
+          background-color: #007880;
           color: var(--color-white);
           text-decoration: none;
         }

--- a/themes/elos/assets/stylesheets/theme-application-elos.scss
+++ b/themes/elos/assets/stylesheets/theme-application-elos.scss
@@ -509,6 +509,48 @@ body.theme-elos {
       margin-bottom: blocks(4);
     }
 
+    .ai-artifacts-announcement {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 4px;
+      padding: 16px 24px;
+      background-color: #EAFAFB;
+      border: 1px solid #2CCCD3;
+      border-radius: 8px;
+      margin-bottom: 40px;
+      text-align: center;
+
+      .announcement-main {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+
+        img {
+          width: 24px;
+          height: 24px;
+          flex-shrink: 0;
+          filter: brightness(0) saturate(100%) invert(45%) sepia(100%) saturate(500%) hue-rotate(148deg) brightness(85%);
+        }
+      }
+
+      .announcement-text {
+        font-size: 16px;
+        color: #202020;
+        margin: 0;
+        line-height: normal;
+      }
+
+      .announcement-subtitle {
+        font-size: 12px;
+        color: #202020;
+        font-style: italic;
+        margin: 0;
+        line-height: normal;
+      }
+    }
+
     .load-meetings {
       display: none;
     }

--- a/themes/elos/config/locales/en.yml
+++ b/themes/elos/config/locales/en.yml
@@ -5,6 +5,9 @@ en:
       link_copied: "Link copied to the clipboard!"
     empty_list: "This page does not have any content yet."
     schedule: "Schedule"
+  ai_artifacts_announcement:
+    text_html: "<strong>New feature:</strong> AI-generated transcriptions and summaries for your recordings!"
+    subtitle_html: "Available for recordings made after <strong>%{date}</strong>."
   ai_features_banner:
     title: "New features!"
     description: "Generate transcriptions and summaries of your recordings with the new Elos AI!"

--- a/themes/elos/config/locales/en.yml
+++ b/themes/elos/config/locales/en.yml
@@ -5,6 +5,11 @@ en:
       link_copied: "Link copied to the clipboard!"
     empty_list: "This page does not have any content yet."
     schedule: "Schedule"
+  ai_features_banner:
+    title: "New features!"
+    description: "Generate transcriptions and summaries of your recordings with the new Elos AI!"
+    cta: "Learn more"
+    close: "Close"
   group_select:
     title: "Select group"
   helpers:

--- a/themes/elos/config/locales/es.yml
+++ b/themes/elos/config/locales/es.yml
@@ -5,6 +5,9 @@ es:
       link_copied: "Link copiado al clipboard!"
     empty_list: "Esta página aún no tiene ningún contenido."
     schedule: "Agendar"
+  ai_artifacts_announcement:
+    text_html: "<strong>Novedad:</strong> ¡transcripciones y resúmenes generados por IA para tus grabaciones!"
+    subtitle_html: "Disponible para grabaciones realizadas a partir del <strong>%{date}</strong>."
   ai_features_banner:
     title: "¡Nuevas funcionalidades!"
     description: "¡Genera transcripciones y resúmenes de tus grabaciones con la nueva IA de Elos!"

--- a/themes/elos/config/locales/es.yml
+++ b/themes/elos/config/locales/es.yml
@@ -5,6 +5,11 @@ es:
       link_copied: "Link copiado al clipboard!"
     empty_list: "Esta página aún no tiene ningún contenido."
     schedule: "Agendar"
+  ai_features_banner:
+    title: "¡Nuevas funcionalidades!"
+    description: "¡Genera transcripciones y resúmenes de tus grabaciones con la nueva IA de Elos!"
+    cta: "Saber más"
+    close: "Cerrar"
   group_select:
     title: "Seleccionar grupo"
   helpers:

--- a/themes/elos/config/locales/pt.yml
+++ b/themes/elos/config/locales/pt.yml
@@ -5,6 +5,9 @@ pt:
       link_copied: "Link copiado para o clipboard!"
     empty_list: "Essa página ainda não possui nenhum conteúdo."
     schedule: "Agendar"
+  ai_artifacts_announcement:
+    text_html: "<strong>Novidade:</strong> transcrições e resumos gerados por IA para suas gravações!"
+    subtitle_html: "Disponível para gravações realizadas a partir do dia <strong>%{date}</strong>."
   ai_features_banner:
     title: "Novas funcionalidades!"
     description: "Gere transcrições e resumos das suas gravações com a nova IA do Elos!"

--- a/themes/elos/config/locales/pt.yml
+++ b/themes/elos/config/locales/pt.yml
@@ -5,6 +5,11 @@ pt:
       link_copied: "Link copiado para o clipboard!"
     empty_list: "Essa página ainda não possui nenhum conteúdo."
     schedule: "Agendar"
+  ai_features_banner:
+    title: "Novas funcionalidades!"
+    description: "Gere transcrições e resumos das suas gravações com a nova IA do Elos!"
+    cta: "Saiba mais"
+    close: "Fechar"
   group_select:
     title: "Selecionar grupo"
   helpers:

--- a/themes/elos/views/shared/_ai_features_banner.html.erb
+++ b/themes/elos/views/shared/_ai_features_banner.html.erb
@@ -1,0 +1,16 @@
+<div id="ai-features-banner" class="ai-features-banner">
+  <div class="content">
+    <div class="icon-title">
+      <%= icon_ai_summary %>
+      <strong class="title"><%= t('ai_features_banner.title') %></strong>
+    </div>
+    <p class="description"><%= t('ai_features_banner.description') %></p>
+    <%= link_to meetings_room_path(room), class: "btn mt-2" do %>
+      <%= t('ai_features_banner.cta') %>
+      <%= icon_arrow_right %>
+    <% end %>
+  </div>
+  <button class="close mt-2" aria-label="<%= t('ai_features_banner.close') %>">
+    <%= icon_not_check %>
+  </button>
+</div>

--- a/themes/elos/views/shared/_meetings.html.erb
+++ b/themes/elos/views/shared/_meetings.html.erb
@@ -40,7 +40,7 @@
         <p class="announcement-text"><%= t('ai_artifacts_announcement.text_html') %></p>
       </div>
       <% if release_date.present? %>
-        <p class="announcement-subtitle"><%= t('ai_artifacts_announcement.subtitle_html', date: l(release_date)) %></p>
+        <p class="announcement-subtitle"><%= t('ai_artifacts_announcement.subtitle_html', date: l(release_date, format: :day_month_year)) %></p>
       <% end %>
     </div>
   <% end %>

--- a/themes/elos/views/shared/_meetings.html.erb
+++ b/themes/elos/views/shared/_meetings.html.erb
@@ -31,6 +31,18 @@
     </div>
   <% end %>
 
+  <%# AI Artifacts announcement %>
+  <% release_date = Rails.configuration.ai_artifacts_release_date %>
+  <div class="ai-artifacts-announcement">
+    <div class="announcement-main">
+      <%= icon_ai_artifacts_rnp %>
+      <p class="announcement-text"><%= t('ai_artifacts_announcement.text_html') %></p>
+    </div>
+    <% if release_date.present? %>
+      <p class="announcement-subtitle"><%= t('ai_artifacts_announcement.subtitle_html', date: l(release_date)) %></p>
+    <% end %>
+  </div>
+
   <div class="row">
     <div class="col-12">
       <table id="meetings-table" class="table" data-search-target="1">

--- a/themes/elos/views/shared/_meetings.html.erb
+++ b/themes/elos/views/shared/_meetings.html.erb
@@ -32,16 +32,18 @@
   <% end %>
 
   <%# AI Artifacts announcement %>
-  <% release_date = Rails.configuration.ai_artifacts_release_date %>
-  <div class="ai-artifacts-announcement">
-    <div class="announcement-main">
-      <%= icon_ai_artifacts_rnp %>
-      <p class="announcement-text"><%= t('ai_artifacts_announcement.text_html') %></p>
+  <% if ai_artifacts_enabled?(room) %>
+    <% release_date = Rails.configuration.ai_artifacts_release_date %>
+    <div class="ai-artifacts-announcement">
+      <div class="announcement-main">
+        <%= icon_ai_artifacts_rnp %>
+        <p class="announcement-text"><%= t('ai_artifacts_announcement.text_html') %></p>
+      </div>
+      <% if release_date.present? %>
+        <p class="announcement-subtitle"><%= t('ai_artifacts_announcement.subtitle_html', date: l(release_date)) %></p>
+      <% end %>
     </div>
-    <% if release_date.present? %>
-      <p class="announcement-subtitle"><%= t('ai_artifacts_announcement.subtitle_html', date: l(release_date)) %></p>
-    <% end %>
-  </div>
+  <% end %>
 
   <div class="row">
     <div class="col-12">

--- a/themes/elos/views/shared/_scheduled_meetings.html.erb
+++ b/themes/elos/views/shared/_scheduled_meetings.html.erb
@@ -21,6 +21,9 @@
      data: { 'tracking-id': 'lti-view-history', 'institution-guid': "#{@institution_guid}" },
      class: "btn btn-light"
     %>
+    <% if ai_artifacts_enabled?(room) && cookies[:ai_features_banner_dismissed].blank? %>
+      <%= render "shared/ai_features_banner", room: room %>
+    <% end %>
   </div>
 
     <% if can_create_scheduled_meeting?(user, room) %>

--- a/themes/rnp/assets/javascripts/theme-application-rnp.js
+++ b/themes/rnp/assets/javascripts/theme-application-rnp.js
@@ -421,6 +421,10 @@ $(document).on('turbolinks:load', function(){
       $showIcon.show();
     });
   });
+
+  $('#ai-features-banner .close, #ai-features-banner .btn').on('click', function() {
+    document.cookie = 'ai_features_banner_dismissed=1; path=/; SameSite=Lax';
+  });
 });
 
 $DOCUMENT.on('turbolinks:load',  () => {

--- a/themes/rnp/assets/stylesheets/theme-application-rnp.scss
+++ b/themes/rnp/assets/stylesheets/theme-application-rnp.scss
@@ -864,6 +864,119 @@ body.theme-rnp {
       padding: blocks(2) $block;
       margin-right: blocks(2);
     }
+
+    #view-meetings {
+      position: relative;
+    }
+
+    .ai-features-banner {
+      position: absolute;
+      top: calc(100% + 10px);
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 100;
+      background-color: #ebf7ff;
+      border-radius: 12px;
+      filter: drop-shadow(4px 4px 4px rgba(32, 32, 32, 0.2));
+      padding: 24px;
+      width: 324px;
+
+      &::before {
+        content: '';
+        position: absolute;
+        top: -8px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 0;
+        height: 0;
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        border-bottom: 8px solid #ebf7ff;
+      }
+
+      .content {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+
+        p {
+          text-align: left;
+        }
+      }
+
+      .icon-title {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 2px;
+
+        img {
+          filter: brightness(0) saturate(100%) invert(26%) sepia(97%) saturate(614%) hue-rotate(195deg) brightness(89%);
+        }
+      }
+
+      .icon {
+        width: 24px;
+        height: 24px;
+      }
+
+      .title {
+        font-size: 18px;
+        font-weight: 700;
+        color: #074AA0;
+        line-height: normal;
+        margin: 0;
+      }
+
+      .description {
+        font-size: 16px;
+        color: #202020;
+        margin: 0;
+        line-height: normal;
+      }
+
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        background-color: #074AA0;
+        color: var(--color-white);
+        border-radius: 8px;
+        padding: 4px 16px 4px 24px;
+        font-weight: 500;
+        font-size: 16px;
+        text-decoration: none;
+        width: fit-content;
+        margin: 0 auto;
+
+        &:hover {
+          background-color: #073d85;
+          color: var(--color-white);
+          text-decoration: none;
+        }
+
+        .icon {
+          color: var(--color-white);
+          font-size: 24px;
+        }
+      }
+
+      .close {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        line-height: 1;
+        color: var(--color-black);
+
+        .icon {
+          font-size: 16px;
+        }
+      }
+    }
   }
 
   #meetings-list {

--- a/themes/rnp/assets/stylesheets/theme-application-rnp.scss
+++ b/themes/rnp/assets/stylesheets/theme-application-rnp.scss
@@ -1009,6 +1009,48 @@ body.theme-rnp {
       margin-bottom: blocks(4);
     }
 
+    .ai-artifacts-announcement {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 4px;
+      padding: 16px 24px;
+      background-color: #ebf7ff;
+      border: 1px solid #4278be;
+      border-radius: 8px;
+      margin-bottom: 40px;
+      text-align: center;
+
+      .announcement-main {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+
+        img {
+          width: 24px;
+          height: 24px;
+          flex-shrink: 0;
+          filter: brightness(0) saturate(100%) invert(26%) sepia(97%) saturate(614%) hue-rotate(195deg) brightness(89%);
+        }
+      }
+
+      .announcement-text {
+        font-size: 16px;
+        color: #202020;
+        margin: 0;
+        line-height: normal;
+      }
+
+      .announcement-subtitle {
+        font-size: 12px;
+        color: #202020;
+        font-style: italic;
+        margin: 0;
+        line-height: normal;
+      }
+    }
+
     .load-meetings {
       display: none;
     }

--- a/themes/rnp/config/locales/en.yml
+++ b/themes/rnp/config/locales/en.yml
@@ -13,6 +13,9 @@ en:
       searching: "Searching"
       space_or_comma: "Press Space or type a comma to confirm the e-mail"
     send: "Send"
+  ai_artifacts_announcement:
+    text_html: "<strong>New feature:</strong> AI-generated transcriptions and summaries for your recordings!"
+    subtitle_html: "Available for recordings made after <strong>%{date}</strong>."
   ai_features_banner:
     title: "New features!"
     description: "Generate transcriptions and summaries of your recordings with the new ConferênciaWeb AI!"

--- a/themes/rnp/config/locales/en.yml
+++ b/themes/rnp/config/locales/en.yml
@@ -13,6 +13,11 @@ en:
       searching: "Searching"
       space_or_comma: "Press Space or type a comma to confirm the e-mail"
     send: "Send"
+  ai_features_banner:
+    title: "New features!"
+    description: "Generate transcriptions and summaries of your recordings with the new ConferênciaWeb AI!"
+    cta: "Learn more"
+    close: "Close"
   group_select:
     title: "Select group"
   helpers:

--- a/themes/rnp/config/locales/es.yml
+++ b/themes/rnp/config/locales/es.yml
@@ -13,6 +13,9 @@ es:
       searching: "Buscando"
       space_or_comma: "Pulse la barra espaciadora o escriba una coma para confirmar el correo electrónico"
     send: "Enviar"
+  ai_artifacts_announcement:
+    text_html: "<strong>Novedad:</strong> ¡transcripciones y resúmenes generados por IA para tus grabaciones!"
+    subtitle_html: "Disponible para grabaciones realizadas a partir del <strong>%{date}</strong>."
   ai_features_banner:
     title: "¡Nuevas funcionalidades!"
     description: "¡Genera transcripciones y resúmenes de tus grabaciones con la nueva IA de ConferênciaWeb!"

--- a/themes/rnp/config/locales/es.yml
+++ b/themes/rnp/config/locales/es.yml
@@ -13,6 +13,11 @@ es:
       searching: "Buscando"
       space_or_comma: "Pulse la barra espaciadora o escriba una coma para confirmar el correo electrónico"
     send: "Enviar"
+  ai_features_banner:
+    title: "¡Nuevas funcionalidades!"
+    description: "¡Genera transcripciones y resúmenes de tus grabaciones con la nueva IA de ConferênciaWeb!"
+    cta: "Saber más"
+    close: "Cerrar"
   group_select:
     title: "Seleccionar grupo"
   helpers:

--- a/themes/rnp/config/locales/pt.yml
+++ b/themes/rnp/config/locales/pt.yml
@@ -13,6 +13,11 @@ pt:
       searching: "Buscando"
       space_or_comma: "Aperte Espaço ou digite uma vírgula para confirmar o e-mail"
     send: "Enviar"
+  ai_features_banner:
+    title: "Novas funcionalidades!"
+    description: "Gere transcrições e resumos das suas gravações com a nova IA do ConferênciaWeb!"
+    cta: "Saiba mais"
+    close: "Fechar"
   group_select:
     title: "Selecionar grupo"
   helpers:

--- a/themes/rnp/config/locales/pt.yml
+++ b/themes/rnp/config/locales/pt.yml
@@ -13,6 +13,9 @@ pt:
       searching: "Buscando"
       space_or_comma: "Aperte Espaço ou digite uma vírgula para confirmar o e-mail"
     send: "Enviar"
+  ai_artifacts_announcement:
+    text_html: "<strong>Novidade:</strong> transcrições e resumos gerados por IA para suas gravações!"
+    subtitle_html: "Disponível para gravações realizadas a partir do dia <strong>%{date}</strong>."
   ai_features_banner:
     title: "Novas funcionalidades!"
     description: "Gere transcrições e resumos das suas gravações com a nova IA do ConferênciaWeb!"

--- a/themes/rnp/views/shared/_ai_features_banner.html.erb
+++ b/themes/rnp/views/shared/_ai_features_banner.html.erb
@@ -1,0 +1,16 @@
+<div id="ai-features-banner" class="ai-features-banner">
+  <div class="content">
+    <div class="icon-title">
+      <%= icon_ai_summary %>
+      <strong class="title"><%= t('ai_features_banner.title') %></strong>
+    </div>
+    <p class="description"><%= t('ai_features_banner.description') %></p>
+    <%= link_to meetings_room_path(room), class: "btn mt-2" do %>
+      <%= t('ai_features_banner.cta') %>
+      <%= icon_arrow_right %>
+    <% end %>
+  </div>
+  <button class="close mt-2" aria-label="<%= t('ai_features_banner.close') %>">
+    <%= icon_not_check %>
+  </button>
+</div>

--- a/themes/rnp/views/shared/_meetings.html.erb
+++ b/themes/rnp/views/shared/_meetings.html.erb
@@ -40,7 +40,7 @@
         <p class="announcement-text"><%= t('ai_artifacts_announcement.text_html') %></p>
       </div>
       <% if release_date.present? %>
-        <p class="announcement-subtitle"><%= t('ai_artifacts_announcement.subtitle_html', date: l(release_date)) %></p>
+        <p class="announcement-subtitle"><%= t('ai_artifacts_announcement.subtitle_html', date: l(release_date, format: :day_month_year)) %></p>
       <% end %>
     </div>
   <% end %>

--- a/themes/rnp/views/shared/_meetings.html.erb
+++ b/themes/rnp/views/shared/_meetings.html.erb
@@ -31,6 +31,18 @@
     </div>
   <% end %>
 
+  <%# AI Artifacts announcement %>
+  <% release_date = Rails.configuration.ai_artifacts_release_date %>
+  <div class="ai-artifacts-announcement">
+    <div class="announcement-main">
+      <%= icon_ai_artifacts_rnp %>
+      <p class="announcement-text"><%= t('ai_artifacts_announcement.text_html') %></p>
+    </div>
+    <% if release_date.present? %>
+      <p class="announcement-subtitle"><%= t('ai_artifacts_announcement.subtitle_html', date: l(release_date)) %></p>
+    <% end %>
+  </div>
+
   <div class="row">
     <div class="col-12">
       <table id="meetings-table" class="table" data-search-target="1">

--- a/themes/rnp/views/shared/_meetings.html.erb
+++ b/themes/rnp/views/shared/_meetings.html.erb
@@ -32,16 +32,18 @@
   <% end %>
 
   <%# AI Artifacts announcement %>
-  <% release_date = Rails.configuration.ai_artifacts_release_date %>
-  <div class="ai-artifacts-announcement">
-    <div class="announcement-main">
-      <%= icon_ai_artifacts_rnp %>
-      <p class="announcement-text"><%= t('ai_artifacts_announcement.text_html') %></p>
+  <% if ai_artifacts_enabled?(room) %>
+    <% release_date = Rails.configuration.ai_artifacts_release_date %>
+    <div class="ai-artifacts-announcement">
+      <div class="announcement-main">
+        <%= icon_ai_artifacts_rnp %>
+        <p class="announcement-text"><%= t('ai_artifacts_announcement.text_html') %></p>
+      </div>
+      <% if release_date.present? %>
+        <p class="announcement-subtitle"><%= t('ai_artifacts_announcement.subtitle_html', date: l(release_date)) %></p>
+      <% end %>
     </div>
-    <% if release_date.present? %>
-      <p class="announcement-subtitle"><%= t('ai_artifacts_announcement.subtitle_html', date: l(release_date)) %></p>
-    <% end %>
-  </div>
+  <% end %>
 
   <div class="row">
     <div class="col-12">

--- a/themes/rnp/views/shared/_scheduled_meetings.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meetings.html.erb
@@ -23,6 +23,9 @@
     data: { 'tracking-id': 'lti-view-history', 'institution-guid': "#{@institution_guid}" },
     class: "btn btn-light"
     %>
+    <% if ai_artifacts_enabled?(room) && cookies[:ai_features_banner_dismissed].blank? %>
+      <%= render "shared/ai_features_banner", room: room %>
+    <% end %>
   </div>
 
   <% if can_create_scheduled_meeting?(user, room) %>


### PR DESCRIPTION
# AI artifacts announcements

Adds two UI elements to announce AI-generated artifacts (transcriptions and summaries) to users, implemented across both Elos and RNP themes.

## What changed

### AI features popover in room main page
  - Adds a floating card anchored below the "View history" button, visible only when `ai_artifacts_enabled?` returns `true` for the consumer; "Learn more" CTA links to the meetings history page;
  - Dismiss state stored in a session cookie (ai_features_banner_dismissed) checked server-side before rendering.

### AI artifacts announcement banner in meetings history page
  - Adds an informational banner, guarded by the `ai_artifacts_enabled?` check;
  - Availability date read from `MCONF_AI_ARTIFACTS_RELEASE_DATE` (expected format: YYYY-MM-DD); subtitle is hidden entirely when the env var is not set;
dded to theme-application-{rnp,elos}.scss; icon colorized via CSS filter chain (blue for RNP, teal for Elos)

## Configuration
  - New env var: `MCONF_AI_ARTIFACTS_RELEASE_DATE` — optional string in YYYY-MM-DD format

## Test plan

  - [ ] With `allow_ai_artifacts: true` set in the consumer config: confirm the popover appears on the room page below the "View history" button;
  - [ ] Click the close button — banner disappears and does not reappear on navigation or page reload (cookie persists for the browser session);
  - [ ] Clear cookies and Click "Learn more" — navigates to history page and banner does not reappear afterwards;
  - [ ] With `allow_ai_artifacts: false` in the consumer config: confirm neither banner renders;
  - [ ] On the history page with` MCONF_AI_ARTIFACTS_RELEASE_DATE=2026-06-18`: confirm the announcement banner appears with the date formatted per the active locale
  - [ ] Without `MCONF_AI_ARTIFACTS_RELEASE_DATE` set: confirm the announcement banner shows only the main text, with no subtitle
  - [ ] Verify date formatting per locale: 18/06/2026 (pt), 06/18/2026 (en), 18/06/2026 (es)