### PR TITLE
[PRT-2693] Restrict AI artifact requests for meetings before the release date

### DIFF
--- a/themes/elos/views/shared/_meeting_row.html.erb
+++ b/themes/elos/views/shared/_meeting_row.html.erb
@@ -108,7 +108,9 @@
         <% if recording[:published] %>
           <% browser_safari = browser.safari? || browser.safari_webapp_mode? %>
           <%# AI Artifacts dropdown %>
-          <% if ai_artifacts_enabled?(@room) %>
+          <% ai_release_date = Rails.configuration.ai_artifacts_release_date %>
+          <% recording_date = Time.at(meeting[:startTime].to_i / 1000.0).to_date %>
+          <% if ai_artifacts_enabled?(@room) && (ai_release_date.nil? || recording_date >= ai_release_date) %>
             <div class="dropdown dropdown-ai-artifacts">
               <a href="#" class="dropdown-toggle text-decoration-none dropdown-ai-artifacts-link"
                 internal-meeting-id="<%= meeting[:internalMeetingID] %>"

--- a/themes/rnp/views/shared/_meeting_row.html.erb
+++ b/themes/rnp/views/shared/_meeting_row.html.erb
@@ -107,7 +107,9 @@
         <% if recording[:published] %>
           <% browser_safari = browser.safari? || browser.safari_webapp_mode? %>
           <%# AI Artifacts dropdown %>
-          <% if ai_artifacts_enabled?(@room) %>
+          <% ai_release_date = Rails.configuration.ai_artifacts_release_date %>
+          <% recording_date = Time.at(meeting[:startTime].to_i / 1000.0).to_date %>
+          <% if ai_artifacts_enabled?(@room) && (ai_release_date.nil? || recording_date >= ai_release_date) %>
             <div class="dropdown dropdown-ai-artifacts">
               <a href="#" class="dropdown-toggle text-decoration-none dropdown-ai-artifacts-link"
                 internal-meeting-id="<%= meeting[:internalMeetingID] %>"


### PR DESCRIPTION
The `MCONF_AI_ARTIFACTS_RELEASE_DATE` env was already used to display an announcement banner, but it wasn't actually hiding the AI artifacts dropdown for meetings that took place before that date.

The AI artifacts dropdown icon in the meeting row is now only rendered when the meeting's start date is on or after the configured release date (or when no release date is set).