### PR TITLE
[PRT-2714] fix: hide AI artifacts dropdown from students in meeting rows

### DIFF
--- a/app/models/abilities.rb
+++ b/app/models/abilities.rb
@@ -32,6 +32,8 @@ class Abilities
   end
 
   def self.full_permission?(user)
+    return false if user.blank?
+
     user.admin? || user.moderator?(self.moderator_roles)
   end
 

--- a/themes/elos/views/shared/_meeting_row.html.erb
+++ b/themes/elos/views/shared/_meeting_row.html.erb
@@ -110,7 +110,7 @@
           <%# AI Artifacts dropdown %>
           <% ai_release_date = Rails.configuration.ai_artifacts_release_date %>
           <% recording_date = Time.at(meeting[:startTime].to_i / 1000.0).to_date %>
-          <% if ai_artifacts_enabled?(@room) && (ai_release_date.nil? || recording_date >= ai_release_date) %>
+          <% if Abilities.full_permission?(user) && ai_artifacts_enabled?(@room) && (ai_release_date.nil? || recording_date >= ai_release_date) %>
             <div class="dropdown dropdown-ai-artifacts">
               <a href="#" class="dropdown-toggle text-decoration-none dropdown-ai-artifacts-link"
                 internal-meeting-id="<%= meeting[:internalMeetingID] %>"

--- a/themes/elos/views/shared/_meetings.html.erb
+++ b/themes/elos/views/shared/_meetings.html.erb
@@ -34,7 +34,7 @@
   <% end %>
 
   <%# AI Artifacts announcement %>
-  <% if ai_artifacts_enabled?(room) && !hide_recordings_history?(room) %>
+  <% if Abilities.full_permission?(user) && ai_artifacts_enabled?(room) && !hide_recordings_history?(room) %>
     <% release_date = Rails.configuration.ai_artifacts_release_date %>
     <div class="ai-artifacts-announcement">
       <div class="announcement-main">

--- a/themes/elos/views/shared/_scheduled_meetings.html.erb
+++ b/themes/elos/views/shared/_scheduled_meetings.html.erb
@@ -21,7 +21,7 @@
      data: { 'tracking-id': 'lti-view-history', 'institution-guid': "#{@institution_guid}" },
      class: "btn btn-light"
     %>
-    <% if ai_artifacts_enabled?(room) && !hide_recordings_history?(room) %>
+    <% if Abilities.full_permission?(user) && ai_artifacts_enabled?(room) && !hide_recordings_history?(room) %>
       <%= render "shared/ai_features_banner", room: room %>
     <% end %>
   </div>

--- a/themes/rnp/views/shared/_meeting_row.html.erb
+++ b/themes/rnp/views/shared/_meeting_row.html.erb
@@ -109,7 +109,7 @@
           <%# AI Artifacts dropdown %>
           <% ai_release_date = Rails.configuration.ai_artifacts_release_date %>
           <% recording_date = Time.at(meeting[:startTime].to_i / 1000.0).to_date %>
-          <% if ai_artifacts_enabled?(@room) && (ai_release_date.nil? || recording_date >= ai_release_date) %>
+          <% if Abilities.full_permission?(user) && ai_artifacts_enabled?(@room) && (ai_release_date.nil? || recording_date >= ai_release_date) %>
             <div class="dropdown dropdown-ai-artifacts">
               <a href="#" class="dropdown-toggle text-decoration-none dropdown-ai-artifacts-link"
                 internal-meeting-id="<%= meeting[:internalMeetingID] %>"

--- a/themes/rnp/views/shared/_meetings.html.erb
+++ b/themes/rnp/views/shared/_meetings.html.erb
@@ -34,7 +34,7 @@
   <% end %>
 
   <%# AI Artifacts announcement %>
-  <% if ai_artifacts_enabled?(room) && !hide_recordings_history?(room) %>
+  <% if Abilities.full_permission?(user) && ai_artifacts_enabled?(room) && !hide_recordings_history?(room) %>
     <% release_date = Rails.configuration.ai_artifacts_release_date %>
     <div class="ai-artifacts-announcement">
       <div class="announcement-main">

--- a/themes/rnp/views/shared/_scheduled_meetings.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meetings.html.erb
@@ -23,7 +23,7 @@
     data: { 'tracking-id': 'lti-view-history', 'institution-guid': "#{@institution_guid}" },
     class: "btn btn-light"
     %>
-    <% if ai_artifacts_enabled?(room) && !hide_recordings_history?(room) %>
+    <% if Abilities.full_permission?(user) && ai_artifacts_enabled?(room) && !hide_recordings_history?(room) %>
       <%= render "shared/ai_features_banner", room: room %>
     <% end %>
   </div>


### PR DESCRIPTION
The dropdown only checked `ai_artifacts_enabled?`/release date, so students could see (and attempt to trigger) the AI artifacts action even though the backend already restricts `:download_artifacts` to moderators/admins. Adds the same `Abilities.full_permission?` check to the elos and rnp `_meeting_row` partials.

Fixes the 500 on meetings_pagination when @user is nil, and keeps the file's fail-closed behavior: no user, no permission.

Promotional elements is now hidden from students: the "Novas funcionalidades" banner on the scheduled meetings screen and the "Novidade" announcement above the recordings history. 

**Visual Changes**

Before:
<img width="391" height="226" alt="image (1)" src="https://github.com/user-attachments/assets/4868d447-212b-4768-86d3-e146597550aa" />

After:
<img width="578" height="157" alt="hide_dropdown_elos_05-47_bbb-app-rooms_05-08" src="https://github.com/user-attachments/assets/ac18d49e-45ca-4417-aab5-1dacd9153204" />
