### PR TITLE
[PRT-2692] feat: error page debug info

### DIFF
--- a/app/assets/javascripts/errors.coffee
+++ b/app/assets/javascripts/errors.coffee
@@ -7,6 +7,16 @@ $(document).on 'click', '#toggle-error-logs', ->
   expanded = $(this).attr('aria-expanded') == 'true'
   $(this).attr('aria-expanded', !expanded)
 
-$(document).on 'click', '#copy-error-logs', ->
-  text = $('#error-debug-info').text()
-  navigator.clipboard.writeText(text)
+# has to wait for turbolinks:load so ClipboardJS is defined by the time this runs.
+$(document).on 'turbolinks:load', ->
+  return unless $('#copy-error-logs').length
+
+  clipboard = new ClipboardJS '#copy-error-logs',
+    text: -> $('#error-debug-info').text()
+
+  clipboard.on 'success', (e) ->
+    e.clearSelection()
+
+    $toast = $('.toast', '#error-logs-copied-toast')
+    $toast.toast('dispose')
+    $toast.toast('show')

--- a/app/assets/javascripts/errors.coffee
+++ b/app/assets/javascripts/errors.coffee
@@ -1,3 +1,12 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
+
+$(document).on 'click', '#toggle-error-logs', ->
+  $('#error-debug-info').toggleClass('d-none')
+  expanded = $(this).attr('aria-expanded') == 'true'
+  $(this).attr('aria-expanded', !expanded)
+
+$(document).on 'click', '#copy-error-logs', ->
+  text = $('#error-debug-info').text()
+  navigator.clipboard.writeText(text)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -183,6 +183,8 @@ class ApplicationController < ActionController::Base
   end
 
   def set_error(model, error, status, context_info: nil)
+    debug_info = build_debug_info
+    can_view_debug = @user.present? && Abilities.full_permission?(@user)
     @user = nil
     instance_variable_set("@#{model}".to_sym, nil)
     context_info ||= [@app_launch&.consumer_key, @app_launch&.nonce].compact
@@ -193,6 +195,8 @@ class ApplicationController < ActionController::Base
       explanation: t("error.#{model}.#{error}.status_code") == '404' ? nil : t("error.#{model}.#{error}.explanation"),
       code: t("error.#{model}.#{error}.status_code"),
       context_info: context_info,
+      debug_info: debug_info,
+      can_view_debug: can_view_debug,
       status: status
     }
   end
@@ -278,6 +282,31 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def build_debug_info
+    calls = Current.moodle_calls || []
+
+    fields = {
+      'consumer_key' => @app_launch&.consumer_key,
+      'moodle_url' => @app_launch&.params&.[]('launch_presentation_return_url'),
+      'tool_consumer' => @app_launch&.params&.[]('tool_consumer_instance_name'),
+      'room_handler' => @room&.handler,
+      'user' => [
+        @user&.uid,
+        @user&.full_name || @app_launch&.omniauth_auth&.dig('bbbltibroker', 'info', 'full_name'),
+        @user&.email || @app_launch&.omniauth_auth&.dig('bbbltibroker', 'info', 'email')
+      ].compact.join(' | ')
+    }
+
+    lines = fields.map { |label, value| "#{"#{label}:".ljust(16)}#{value.presence || '-'}" }
+    lines << '' << "moodle_calls (#{calls.size}):"
+    lines << '  nenhuma chamada nesta requisicao' if calls.empty?
+    lines += calls.map.with_index(1) do |call, index|
+      "  #{index}. #{call[:wsfunction]} -> #{call[:errorcode] || call[:status]} (#{call[:duration]}s)"
+    end
+
+    lines.join("\n")
+  end
+
   def render_error(status)
     model = 'generic'
     @error = {
@@ -287,6 +316,8 @@ class ApplicationController < ActionController::Base
       suggestion: t("error.#{model}.#{status}.suggestion"),
       explanation: status == 404 ? nil : t("error.#{model}.#{status}.explanation"),
       code: status,
+      debug_info: build_debug_info,
+      can_view_debug: @user.present? && Abilities.full_permission?(@user),
       status: status
     }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -298,7 +298,7 @@ class ApplicationController < ActionController::Base
     }
 
     lines = fields.map { |label, value| "#{"#{label}:".ljust(16)}#{value.presence || '-'}" }
-    lines << '' << "moodle_calls (#{calls.size}):"
+    lines << '' << "moodle_calls (#{Current.moodle_calls_count_label}):"
     lines << '  nenhuma chamada nesta requisicao' if calls.empty?
     lines += calls.map.with_index(1) do |call, index|
       "  #{index}. #{call[:wsfunction]} -> #{call[:errorcode] || call[:status]} (#{call[:duration]}s)"

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Holds state scoped to the current unit of work (a request or a job). Rails
+# resets it automatically when the unit of work ends
+
+class Current < ActiveSupport::CurrentAttributes
+  MAX_MOODLE_CALLS = 15
+
+  attribute :moodle_calls
+  before_reset :log_moodle_calls
+
+  def record_moodle_call(wsfunction:, status:, duration: nil, errorcode: nil)
+    self.moodle_calls ||= []
+    return if moodle_calls.size >= MAX_MOODLE_CALLS
+
+    moodle_calls << {
+      wsfunction: wsfunction,
+      status: status,
+      duration: duration&.round(3),
+      errorcode: errorcode
+    }.compact
+  end
+
+  def log_moodle_calls
+    return if moodle_calls.blank?
+
+    summary = moodle_calls.map do |call|
+      "#{call[:wsfunction]}:#{call[:errorcode] || call[:status]}:#{call[:duration]}s"
+    end.join(', ')
+
+    Rails.logger.info "[MOODLE SEQ] calls=#{moodle_calls.size} " \
+                      "errors=#{moodle_calls.count { |c| c[:status] != 'ok' }} " \
+                      "[#{summary}]"
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -23,9 +23,10 @@ class Current < ActiveSupport::CurrentAttributes
   end
 
   def moodle_calls_count_label
-    return moodle_calls.size.to_s if moodle_calls_total.to_i <= moodle_calls.size
+    size = moodle_calls.to_a.size
+    return size.to_s if moodle_calls_total.to_i <= size
 
-    "#{moodle_calls.size}/#{moodle_calls_total} (truncated)"
+    "#{size}/#{moodle_calls_total} (truncated)"
   end
 
   def log_moodle_calls

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -6,11 +6,12 @@
 class Current < ActiveSupport::CurrentAttributes
   MAX_MOODLE_CALLS = 15
 
-  attribute :moodle_calls
+  attribute :moodle_calls, :moodle_calls_total
   before_reset :log_moodle_calls
 
   def record_moodle_call(wsfunction:, status:, duration: nil, errorcode: nil)
     self.moodle_calls ||= []
+    self.moodle_calls_total = (moodle_calls_total || 0) + 1
     return if moodle_calls.size >= MAX_MOODLE_CALLS
 
     moodle_calls << {
@@ -21,6 +22,12 @@ class Current < ActiveSupport::CurrentAttributes
     }.compact
   end
 
+  def moodle_calls_count_label
+    return moodle_calls.size.to_s if moodle_calls_total.to_i <= moodle_calls.size
+
+    "#{moodle_calls.size}/#{moodle_calls_total} (truncated)"
+  end
+
   def log_moodle_calls
     return if moodle_calls.blank?
 
@@ -28,7 +35,7 @@ class Current < ActiveSupport::CurrentAttributes
       "#{call[:wsfunction]}:#{call[:errorcode] || call[:status]}:#{call[:duration]}s"
     end.join(', ')
 
-    Rails.logger.info "[MOODLE SEQ] calls=#{moodle_calls.size} " \
+    Rails.logger.info "[MOODLE SEQ] calls=#{moodle_calls_count_label} " \
                       "errors=#{moodle_calls.count { |c| c[:status] != 'ok' }} " \
                       "[#{summary}]"
   end

--- a/app/views/shared/error.html.erb
+++ b/app/views/shared/error.html.erb
@@ -18,5 +18,20 @@
     <div class="context-info text-muted fs-xxs mt-2">
       <%= @error[:context_info] %>
     </div>
+    <% if @error[:can_view_debug] %>
+      <div class="error-debug mt-4">
+        <button type="button" class="btn btn-primary btn-sm" id="toggle-error-logs"
+                aria-expanded="false" aria-controls="error-debug-info">
+          Ver mais
+        </button>
+        <button type="button" class="btn btn-light btn-sm d-inline-flex align-items-center gap-1" id="copy-error-logs">
+          <i class="icon material-icons fs-6">content_copy</i>
+          Copiar
+        </button>
+        <pre class="error-debug-info mt-2 d-none text-start border rounded p-3 mx-auto font-monospace fs-xxs overflow-auto"
+             style="max-height: 320px; max-width: 860px; background-color: #faf9f6;"
+             id="error-debug-info"><%= @error[:debug_info] %></pre>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/error.html.erb
+++ b/app/views/shared/error.html.erb
@@ -31,6 +31,7 @@
         <pre class="error-debug-info mt-2 d-none text-start border rounded p-3 mx-auto font-monospace fs-xxs overflow-auto"
              style="max-height: 320px; max-width: 860px; background-color: #faf9f6;"
              id="error-debug-info"><%= @error[:debug_info] %></pre>
+        <%= render 'shared/toast', toast_id: 'error-logs-copied-toast', text: t('default.app.error_debug_info_copied') %>
       </div>
     <% end %>
   </div>

--- a/app/views/shared/error.html.erb
+++ b/app/views/shared/error.html.erb
@@ -22,11 +22,11 @@
       <div class="error-debug mt-4">
         <button type="button" class="btn btn-primary btn-sm" id="toggle-error-logs"
                 aria-expanded="false" aria-controls="error-debug-info">
-          Ver mais
+          <%= t('default.app.error_debug_info') %>
         </button>
         <button type="button" class="btn btn-light btn-sm d-inline-flex align-items-center gap-1" id="copy-error-logs">
           <i class="icon material-icons fs-6">content_copy</i>
-          Copiar
+          <%= t('default.app.content_copy') %>
         </button>
         <pre class="error-debug-info mt-2 d-none text-start border rounded p-3 mx-auto font-monospace fs-xxs overflow-auto"
              style="max-height: 320px; max-width: 860px; background-color: #faf9f6;"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
       data_api_config_error: "Data API configuration error. Please contact support."
       error:          "Error"
       error_debug_info: "See more"
+      error_debug_info_copied: "Copied to clipboard"
       content_copy:    "Copy"
     admin:
       back:           "Back"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,8 @@ en:
       data_api_error:   "Communication error with the Data API. Please try again or contact support."
       data_api_config_error: "Data API configuration error. Please contact support."
       error:          "Error"
+      error_debug_info: "See more"
+      content_copy:    "Copy"
     admin:
       back:           "Back"
       handler:        "Handler"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -7,6 +7,7 @@ es:
       error:          "Error"
       error_debug_info: "Ver más"
       content_copy:    "Copiar"
+      error_debug_info_copied: "Copiado al clipboard"
     admin:
       back:           "Vuelve"
       handler:        "Handler"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5,6 +5,8 @@ es:
       data_api_error:   "Error de comunicación con la API de Datos. Vuelva a intentarlo o póngase en contacto con el servicio de asistencia."
       data_api_config_error: "Error de configuración de la API de Datos. Póngase en contacto con el servicio de asistencia."
       error:          "Error"
+      error_debug_info: "Ver más"
+      content_copy:    "Copiar"
     admin:
       back:           "Vuelve"
       handler:        "Handler"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -6,6 +6,7 @@ pt:
       data_api_config_error: "Erro na configuração da API de Dados. Por favor, entre em contato com o suporte."
       error:          "Erro"
       error_debug_info: "Ver mais"
+      error_debug_info_copied: "Copiado para a área de transferência"
       content_copy:    "Copiar"
     admin:
       back:           "Voltar"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -5,6 +5,8 @@ pt:
       data_api_error:   "Erro de comunicação com a API de Dados. Por favor, tente novamente ou entre em contato com o suporte."
       data_api_config_error: "Erro na configuração da API de Dados. Por favor, entre em contato com o suporte."
       error:          "Erro"
+      error_debug_info: "Ver mais"
+      content_copy:    "Copiar"
     admin:
       back:           "Voltar"
       handler:        "Handler"

--- a/lib/moodle.rb
+++ b/lib/moodle.rb
@@ -625,6 +625,11 @@ module Moodle
           result = res.body.is_a?(Hash) ? res.body.merge({"duration" => duration}) :
                                           { "body" => res.body, "duration" => duration }
 
+          # Moodle answers with 200 even for its own errors, reporting them in
+          # the body, which is why every caller checks result["exception"].
+          failed = res.body.is_a?(Hash) && res.body['exception'].present?
+          record_call(params, duration, failed ? 'error' : 'ok', (res.body['errorcode'] if failed))
+
           Rails.logger.debug("[MOODLE API] Calling URL: #{host_url}?#{params.to_a.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')} | Moodle response: #{res.inspect}")
           return result
 
@@ -636,6 +641,7 @@ module Moodle
                               "message=\"Request failed (Faraday::ResourceNotFound): #{e}\" " \
                               "response_body=\"#{e.response_body&.gsub(/\n/, '')}\""
                             )
+          record_call(params, Time.now - start_time, 'url_not_found')
           raise UrlNotFoundError, e
         rescue Faraday::TimeoutError => e
           Rails.logger.error( "[MOODLE API] url=#{host_url} " \
@@ -643,6 +649,7 @@ module Moodle
                               "wsfunction=#{params[:wsfunction]} " \
                               "caller=#{caller(2..3)} " \
                               "message=\"Request failed (Faraday::TimeoutError): #{e}\"")
+          record_call(params, Time.now - start_time, 'timeout')
           raise TimeoutError, e
         rescue Faraday::Error => e
           Rails.logger.error( "[MOODLE API] url=#{host_url} " \
@@ -652,6 +659,7 @@ module Moodle
                               "message=\"Request failed (Faraday::Error): #{e}\" " \
                               "response_body=\"#{e.response_body&.gsub(/\n/, '')}\""
                             )
+          record_call(params, Time.now - start_time, 'request_error')
           raise RequestError, e
         end
       rescue Moodle::UrlNotFoundError, Moodle::TimeoutError, Moodle::RequestError => e
@@ -666,6 +674,18 @@ module Moodle
           raise e
         end
       end
+    end
+
+    # Records one entry in the sequence of Moodle calls of the current request.
+    def self.record_call(params, duration, status, errorcode = nil)
+      Current.record_moodle_call(
+        wsfunction: params[:wsfunction],
+        status: status,
+        duration: duration,
+        errorcode: errorcode
+      )
+    rescue StandardError => e
+      Rails.logger.warn "[MOODLE API] Failed to record the call: #{e.class}: #{e.message}"
     end
   end
 

--- a/lib/moodle.rb
+++ b/lib/moodle.rb
@@ -603,18 +603,18 @@ module Moodle
             break unless (300...400).cover?(res.status)
 
             redirect_count += 1
-            raise RequestError, "Too many redirects" if redirect_count > MAX_REDIRECTS
+            raise RequestError.new("Too many redirects", status: 'too_many_redirects') if redirect_count > MAX_REDIRECTS
 
             location = res.headers['location']
-            raise RequestError, "Redirect missing Location header" if location.blank?
+            raise RequestError.new("Redirect missing Location header", status: 'redirect_missing_location') if location.blank?
 
             original_uri = URI.parse(current_url)
             redirect_uri = URI.parse(location)
 
-            raise RequestError, "Redirect to different host" \
+            raise RequestError.new("Redirect to different host", status: 'redirect_different_host') \
               unless original_uri.host == redirect_uri.host
 
-            raise RequestError, "Unsafe redirect scheme change" \
+            raise RequestError.new("Unsafe redirect scheme change", status: 'redirect_unsafe_scheme') \
               unless original_uri.scheme == redirect_uri.scheme ||
                      (original_uri.scheme == 'http' && redirect_uri.scheme == 'https')
 
@@ -661,6 +661,15 @@ module Moodle
                             )
           record_call(params, Time.now - start_time, 'request_error')
           raise RequestError, e
+        rescue Moodle::RequestError => e
+          Rails.logger.error( "[MOODLE API] url=#{host_url} " \
+                              "duration=#{(Time.now - start_time).round(3)}s " \
+                              "wsfunction=#{params[:wsfunction]} " \
+                              "caller=#{caller(2..3)} " \
+                              "message=\"#{e.message}\""
+                            )
+          record_call(params, Time.now - start_time, e.status)
+          raise
         end
       rescue Moodle::UrlNotFoundError, Moodle::TimeoutError, Moodle::RequestError => e
         if (retries += 1) < MAX_RETRIES
@@ -691,5 +700,13 @@ module Moodle
 
   class UrlNotFoundError < StandardError; end
   class TimeoutError < StandardError; end
-  class RequestError < StandardError; end
+
+  class RequestError < StandardError
+    attr_reader :status
+
+    def initialize(message = nil, status: 'redirect_error')
+      super(message)
+      @status = status
+    end
+  end
 end

--- a/spec/models/current_spec.rb
+++ b/spec/models/current_spec.rb
@@ -50,6 +50,19 @@ RSpec.describe Current, type: :model do
     end
   end
 
+  describe '#moodle_calls_count_label' do
+    it 'returns zero when no call was recorded' do
+      expect(Current.moodle_calls).to be_nil
+      expect(Current.moodle_calls_count_label).to eq('0')
+    end
+
+    it 'returns just the size when nothing was truncated' do
+      Current.record_moodle_call(wsfunction: 'core_webservice_get_site_info', status: 'ok', duration: 0.1)
+
+      expect(Current.moodle_calls_count_label).to eq('1')
+    end
+  end
+
   describe '#log_moodle_calls' do
     it 'logs a single consolidated line on reset' do
       Current.record_moodle_call(wsfunction: 'core_webservice_get_site_info', status: 'ok', duration: 0.211)

--- a/spec/models/current_spec.rb
+++ b/spec/models/current_spec.rb
@@ -32,12 +32,14 @@ RSpec.describe Current, type: :model do
       expect(Current.moodle_calls.first).not_to have_key(:errorcode)
     end
 
-    it 'stops recording after the limit' do
+    it 'stops recording after the limit, but keeps counting the total' do
       (Current::MAX_MOODLE_CALLS + 5).times do
         Current.record_moodle_call(wsfunction: 'core_webservice_get_site_info', status: 'ok', duration: 0.1)
       end
 
       expect(Current.moodle_calls.size).to eq(Current::MAX_MOODLE_CALLS)
+      expect(Current.moodle_calls_total).to eq(Current::MAX_MOODLE_CALLS + 5)
+      expect(Current.moodle_calls_count_label).to eq("#{Current::MAX_MOODLE_CALLS}/#{Current::MAX_MOODLE_CALLS + 5} (truncated)")
     end
 
     it 'does not leak between resets' do

--- a/spec/models/current_spec.rb
+++ b/spec/models/current_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe Current, type: :model do
+  after { Current.reset }
+
+  describe '.record_moodle_call' do
+    it 'keeps the calls in the order they happened' do
+      Current.record_moodle_call(wsfunction: 'core_webservice_get_site_info', status: 'ok', duration: 0.2111)
+      Current.record_moodle_call(
+        wsfunction: 'core_course_get_course_module_by_instance',
+        status: 'error',
+        duration: 0.18,
+        errorcode: 'usernotfullysetup'
+      )
+
+      expect(Current.moodle_calls).to eq(
+        [
+          { wsfunction: 'core_webservice_get_site_info', status: 'ok', duration: 0.211 },
+          {
+            wsfunction: 'core_course_get_course_module_by_instance',
+            status: 'error',
+            duration: 0.18,
+            errorcode: 'usernotfullysetup'
+          }
+        ]
+      )
+    end
+
+    it 'omits the errorcode when there is none' do
+      Current.record_moodle_call(wsfunction: 'core_group_get_course_user_groups', status: 'ok', duration: 0.1)
+
+      expect(Current.moodle_calls.first).not_to have_key(:errorcode)
+    end
+
+    it 'stops recording after the limit' do
+      (Current::MAX_MOODLE_CALLS + 5).times do
+        Current.record_moodle_call(wsfunction: 'core_webservice_get_site_info', status: 'ok', duration: 0.1)
+      end
+
+      expect(Current.moodle_calls.size).to eq(Current::MAX_MOODLE_CALLS)
+    end
+
+    it 'does not leak between resets' do
+      Current.record_moodle_call(wsfunction: 'core_webservice_get_site_info', status: 'ok', duration: 0.1)
+      Current.reset
+
+      expect(Current.moodle_calls).to be_nil
+    end
+  end
+
+  describe '#log_moodle_calls' do
+    it 'logs a single consolidated line on reset' do
+      Current.record_moodle_call(wsfunction: 'core_webservice_get_site_info', status: 'ok', duration: 0.211)
+      Current.record_moodle_call(
+        wsfunction: 'core_course_get_course_module_by_instance',
+        status: 'error',
+        duration: 0.18,
+        errorcode: 'usernotfullysetup'
+      )
+
+      expect(Rails.logger).to receive(:info).with(
+        '[MOODLE SEQ] calls=2 errors=1 ' \
+        '[core_webservice_get_site_info:ok:0.211s, ' \
+        'core_course_get_course_module_by_instance:usernotfullysetup:0.18s]'
+      )
+
+      Current.reset
+    end
+
+    it 'logs nothing when no Moodle call was made' do
+      expect(Rails.logger).not_to receive(:info)
+
+      Current.reset
+    end
+  end
+end


### PR DESCRIPTION
This PR extends the error page's debug panel (visible only to moderators/admins) to include the sequence of Moodle calls made during the request, so support can better diagnose LTI/Moodle integration failures. Both Elos and RNP themes.

Adds a Current attribute, scoped to the unit of work (request or job), that accumulates the outcome of each Moodle API call (function, status, duration) capped at MAX_MOODLE_CALLS to bound memory on runaway retries.  A separate total counter keeps incrementing past the cap, so the panel reports e.g. `15/40 (truncated)` instead of silently understating how many calls actually happened. 

Every return path of Moodle::API.post (success, Moodle-reported error, 404, timeout, connection failure) now records into it, and a consolidated [MOODLE SEQ] line is logged whenever the unit of work ends. This now also covers the redirect-following loop, each cause now records with its own status (`too_many_redirects`, `redirect_missing_location`, `redirect_different_host`, `redirect_unsafe_scheme`) instead of vanishing or falling under a generic label.

ApplicationController exposes this sequence as plain text via build_debug_info, gated behind the existing moderator/admin check, so support can diagnose LTI/Moodle integration failures without server log access.

Adds the "Ver mais" / "Copiar" controls to shared/error, expanding a plain-text panel with the debug info already exposed by ApplicationController. Toggle keeps aria-expanded in sync; copy uses navigator.clipboard, which requires a secure context.

**Visual Changes**
<img width="907" height="618" alt="placeholder_elos_07-54_bbb-app-rooms_11-08" src="https://github.com/user-attachments/assets/66a0e6e1-1fed-4221-be28-0f6d652efb0d" />
<img width="907" height="618" alt="placeholder_rnp_07-56_bbb-app-rooms_11-08" src="https://github.com/user-attachments/assets/621012e0-2eba-49cd-a1b5-b5781ab21b7a" />


