### PR TITLE
[PRT-2733] feat: improve ai artifacts loading UX

### DIFF
--- a/app/assets/javascripts/meetings.js
+++ b/app/assets/javascripts/meetings.js
@@ -287,6 +287,9 @@ let showMeetings = (rows) => {
 
 let downloadAiArtifacts = async(meeting_id, download_artifacts_endpoint) => {
   if (!download_artifacts_endpoint) return;
+
+  showAiArtifactsLoading(meeting_id);
+
   try {
     let response = await doAjaxDownloadArtifacts(download_artifacts_endpoint);
     showAiArtifactItems(response, meeting_id);
@@ -321,6 +324,15 @@ let scheduleAiArtifactsAutoClose = (toggle) => {
     delete aiArtifactsAutoCloseTimers[meeting_id];
     bootstrap.Dropdown.getOrCreateInstance(toggle).hide();
   }, AI_ARTIFACTS_AUTO_CLOSE_DELAY);
+};
+
+/* Every open refetches, so the contents rendered on the previous open are dropped
+   and the placeholder comes back while the new request is in flight. Otherwise the
+   old contents would stay on screen as if they were the current ones. */
+let showAiArtifactsLoading = (meeting_id) => {
+  const containerSelector = `div[aria-labelledby="dropdown-ai-artifacts-${meeting_id}"]`;
+  $(`${containerSelector} .appended-item`).remove();
+  $(`${containerSelector} .dropdown-item-loading`).show();
 };
 
 let showAiArtifactItems = (html, meeting_id) => {

--- a/app/assets/javascripts/meetings.js
+++ b/app/assets/javascripts/meetings.js
@@ -299,6 +299,30 @@ let downloadAiArtifacts = async(meeting_id, download_artifacts_endpoint) => {
   }
 };
 
+const AI_ARTIFACTS_AUTO_CLOSE_DELAY = 2 * 60 * 1000;
+
+// One timer per dropdown, since each recording has its own
+let aiArtifactsAutoCloseTimers = {};
+
+let clearAiArtifactsAutoClose = (toggle) => {
+  const meeting_id = toggle.getAttribute('internal-meeting-id');
+  if (!aiArtifactsAutoCloseTimers[meeting_id]) return;
+
+  clearTimeout(aiArtifactsAutoCloseTimers[meeting_id]);
+  delete aiArtifactsAutoCloseTimers[meeting_id];
+};
+
+let scheduleAiArtifactsAutoClose = (toggle) => {
+  // Drop the previous timer, otherwise it would close a dropdown the user just reopened
+  clearAiArtifactsAutoClose(toggle);
+
+  const meeting_id = toggle.getAttribute('internal-meeting-id');
+  aiArtifactsAutoCloseTimers[meeting_id] = setTimeout(() => {
+    delete aiArtifactsAutoCloseTimers[meeting_id];
+    bootstrap.Dropdown.getOrCreateInstance(toggle).hide();
+  }, AI_ARTIFACTS_AUTO_CLOSE_DELAY);
+};
+
 let showAiArtifactItems = (html, meeting_id) => {
   const containerSelector = `div[aria-labelledby="dropdown-ai-artifacts-${meeting_id}"]`;
   $(`${containerSelector} .dropdown-item-loading`).hide();
@@ -323,8 +347,13 @@ $DOCUMENT.on('click', '.dropdown-download-link', function(e) {
   downloadArtifacts(this.getAttribute('internal-meeting-id'), this.getAttribute('download-artifacts-endpoint'), 'dropdown-download');
 });
 
-$DOCUMENT.on('click', '.dropdown-ai-artifacts-link', function(e) {
+$DOCUMENT.on('shown.bs.dropdown', '.dropdown-ai-artifacts-link', function(e) {
   downloadAiArtifacts(this.getAttribute('internal-meeting-id'), this.getAttribute('download-artifacts-endpoint'));
+  scheduleAiArtifactsAutoClose(this);
+});
+
+$DOCUMENT.on('hidden.bs.dropdown', '.dropdown-ai-artifacts-link', function(e) {
+  clearAiArtifactsAutoClose(this);
 });
 
 $(document).on('click', '.request-ai-artifacts-btn', function(e) {

--- a/app/assets/javascripts/meetings.js
+++ b/app/assets/javascripts/meetings.js
@@ -285,13 +285,24 @@ let showMeetings = (rows) => {
   }
 };
 
+// The request in flight for each dropdown, so a response is only rendered while
+// it is still the latest one asked for
+let aiArtifactsLatestRequest = {};
+
 let downloadAiArtifacts = async(meeting_id, download_artifacts_endpoint) => {
   if (!download_artifacts_endpoint) return;
 
   showAiArtifactsLoading(meeting_id);
 
+  /* Opening and closing the dropdown quickly leaves more than one request in
+     flight, and they can come back out of order */
+  const request = doAjaxDownloadArtifacts(download_artifacts_endpoint);
+  aiArtifactsLatestRequest[meeting_id] = request;
+
   try {
-    let response = await doAjaxDownloadArtifacts(download_artifacts_endpoint);
+    let response = await request;
+    if (aiArtifactsLatestRequest[meeting_id] !== request) return;
+
     showAiArtifactItems(response, meeting_id);
   } catch(err) {
     if (err.statusText == 'timeout') {


### PR DESCRIPTION
This PR improves the AI artifacts loading UX. Artifact generation status is never pushed to the browser, so a dropdown left open keeps showing whatever it was rendered with. The dropdown now closes itself after two minutes, and reopening it re-renders the contents with the current status.

Fetch the dropdown content on shown.bs.dropdown instead of on the click that opens it, so every reopen renders the current status, and schedule a 2 minute timer that closes the dropdown to force that reopen. The timer is kept per dropdown, keyed by internal-meeting-id, and cleared both when rescheduling and on hidden.bs.dropdown, so a timer armed on an earlier open cannot close a dropdown the user has just reopened.