### PR TITLE
[PRT-2743] Fix auth popup closing before the CAFe login flow completes

### DIFF
--- a/app/assets/javascripts/meetings.js
+++ b/app/assets/javascripts/meetings.js
@@ -229,21 +229,45 @@ let hideAll = () => {
 };
 
 var authWindow;
+// Origin the callback page is served from, read from the redirect_uri of the
+// authorization URL instead of being assumed to be ours, since the callback can
+// be configured on a different host than the one serving this page.
+var authWindowOrigin;
 function openAuthWindow(url, service) {
   authWindow = window.open(url, service, 'width=800,height=600');
+  const redirectUri = new URL(url, window.location.href).searchParams.get('redirect_uri');
+  authWindowOrigin = redirectUri ? new URL(redirectUri, window.location.href).origin : window.location.origin;
 }
 
-window.addEventListener('message', function(event) {
-  // Verify the origin of the message
-  if (event.source === authWindow) {
-    authWindow.close()
-    const room_path = $("#room_path")[0].value
-    $.ajax({
-      url: room_path + '/recording/' + event.data['record_id'] + '/' + event.data['service_name'],
-      type: "POST",
-      data: { access_token: event.data['access_token'], refresh_token: event.data['refresh_token'], expires_at: event.data['expires_at']  }
-    });
+/* Check whether a message is the one posted by our own OAuth callback page.
+ *
+ * The login pages loaded inside the popup also post messages to the opener, and
+ * they share the same event.source as our callback, so checking the source
+ * alone would close the popup in the middle of the login flow.
+*/
+let isAuthCallbackMessage = (event) => {
+  if (event.source !== authWindow) return false;
+  if (event.data === null || typeof event.data !== 'object') return false;
+  if (event.data.source !== 'bbb-app-rooms') return false;
+
+  if (event.origin !== authWindowOrigin) {
+    console.warn(`Ignored a callback message from ${event.origin}, expected ${authWindowOrigin}`);
+    return false;
   }
+
+  return true;
+};
+
+window.addEventListener('message', function(event) {
+  if (!isAuthCallbackMessage(event)) return;
+
+  authWindow.close()
+  const room_path = $("#room_path")[0].value
+  $.ajax({
+    url: room_path + '/recording/' + event.data['record_id'] + '/' + event.data['service_name'],
+    type: "POST",
+    data: { access_token: event.data['access_token'], refresh_token: event.data['refresh_token'], expires_at: event.data['expires_at']  }
+  });
 });
 /* Request the meeting artifacts to Data API.
 */

--- a/themes/rnp/assets/javascripts/theme-application-rnp.js
+++ b/themes/rnp/assets/javascripts/theme-application-rnp.js
@@ -442,7 +442,10 @@ $DOCUMENT.on('turbolinks:load',  () => {
   const expiresAt = $("#expires_at")[0].value
   const recordID = $("#recordID")[0].value
   const service_name = $("#service_name")[0].value
+  // The source tag lets the opener tell this message apart from the ones the
+  // login provider posts from inside this same popup.
   window.opener.postMessage({
+    source: 'bbb-app-rooms',
     access_token: accessToken,
     refresh_token: refreshToken,
     expires_at: expiresAt,


### PR DESCRIPTION
The Eduplay/Filesender authentication popup was closing in the middle of the login flow, before the user could finish authenticating.

The login pages loaded inside the popup post their own `message` events to the opener as part of their flow. Those messages carry the same `event.source` as our callback page — `event.source` identifies the popup window, not the document or origin loaded in it — so the opener treated the first one as the OAuth result: it closed the window mid-login and POSTed an empty token to `/recording/...`.

**Changes**

- `themes/rnp/assets/javascripts/theme-application-rnp.js`: the callback page now tags its message with `source: 'bbb-app-rooms'`.
- `app/assets/javascripts/meetings.js`: the opener only acts on messages that carry that tag and come from the origin the authorization URL redirects to. That origin is read from the `redirect_uri` of the URL being opened rather than assumed to be `window.location.origin`, so it stays correct when the callback is configured on a different host than the page. A message that matches the tag but not the origin logs a warning, so a mismatched callback URL is diagnosable instead of silently hanging the popup.
