### PR TITLE
[PRT-2410] Mark Moodle attendance by percentage of participation time

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -456,7 +456,10 @@ class RoomsController < ApplicationController
         url: moodle_configs['url'],
         token: moodle_configs['token'],
         group_select_enabled: moodle_configs['group_select_enabled'],
-        show_all_groups: moodle_configs['show_all_groups']
+        show_all_groups: moodle_configs['show_all_groups'],
+        presence_percentage_enabled: moodle_configs['presence_percentage_enabled'],
+        presence_threshold_percentage: moodle_configs['presence_threshold_percentage'],
+        partial_presence_threshold_percentage: moodle_configs['partial_presence_threshold_percentage']
       )
       Rails.logger.info "[setup_consumer_configs] MoodleToken created/updated, params=#{moodle_configs}"
     else

--- a/app/jobs/moodle_attendance_job.rb
+++ b/app/jobs/moodle_attendance_job.rb
@@ -71,7 +71,11 @@ class MoodleAttendanceJob < ApplicationJob
     return unless session_id
 
     # 3. Get status ids
-    status_ids = get_presence_and_absence_status_ids(moodle_token, session_id)
+    status_ids = if moodle_token.presence_percentage_enabled?
+                   resolve_attendance_status_ids(moodle_token, session_id)
+                 else
+                   get_presence_and_absence_status_ids(moodle_token, session_id)
+                 end
     presence_status_id = status_ids[:presence_status_id]
     absence_status_id = status_ids[:absence_status_id]
 
@@ -85,7 +89,11 @@ class MoodleAttendanceJob < ApplicationJob
     end
 
     # 4. Mark Attendance for Users
-    mark_attendance_for_users(moodle_token, session_id, presence_status_id, absence_status_id, conference_data, course_id)
+    if moodle_token.presence_percentage_enabled?
+      mark_attendance_for_users_by_percentage(moodle_token, session_id, status_ids, conference_data, course_id)
+    else
+      mark_attendance_for_users(moodle_token, session_id, presence_status_id, absence_status_id, conference_data, course_id)
+    end
 
     Resque.logger.info "[MoodleAttendanceJob] Finished processing for scheduled_meeting #{scheduled_meeting.id}."
   end
@@ -139,6 +147,22 @@ class MoodleAttendanceJob < ApplicationJob
   end
 
   def create_moodle_session(moodle_token, attendance_id, scheduled_meeting, conference_data, app_launch, group_select_enabled, theme, locale)
+    # Use internal_meeting_id (not scheduled_meeting_id) to detect if this is a retry of the same occurrence or a new one
+    incoming_internal_meeting_id = conference_data['internal_meeting_id']
+    existing_session_id = scheduled_meeting.moodle_attendance_session_id
+    same_occurrence = existing_session_id.present? &&
+                       incoming_internal_meeting_id.present? &&
+                       scheduled_meeting.moodle_attendance_internal_meeting_id == incoming_internal_meeting_id
+
+    if same_occurrence
+      existing_session = Moodle::API.get_session(moodle_token, existing_session_id)
+      if existing_session.present?
+        Resque.logger.info "[MoodleAttendanceJob] Reusing existing Moodle session ID #{existing_session_id} for scheduled_meeting #{scheduled_meeting.id} (internal_meeting_id=#{incoming_internal_meeting_id})."
+        return existing_session_id
+      end
+      Resque.logger.warn "[MoodleAttendanceJob] Stored moodle_attendance_session_id #{existing_session_id} for scheduled_meeting #{scheduled_meeting.id} is no longer valid on Moodle. Creating a new session."
+    end
+
     current_consumer_config = moodle_token.consumer_config
     theme_display_name = case theme
                          when 'rnp'
@@ -186,6 +210,10 @@ class MoodleAttendanceJob < ApplicationJob
       return nil
     end
     Resque.logger.info "[MoodleAttendanceJob] Created Moodle session with ID: #{session_id} ---- #{session_id.inspect}."
+    scheduled_meeting.update!(
+      moodle_attendance_session_id: session_id,
+      moodle_attendance_internal_meeting_id: incoming_internal_meeting_id
+    )
     session_id
   end
 
@@ -220,6 +248,37 @@ class MoodleAttendanceJob < ApplicationJob
     end
     
     { presence_status_id: presence_status_id, absence_status_id: absence_status_id }
+  end
+
+  def resolve_attendance_status_ids(moodle_token, session_id)
+    session_statuses = Moodle::API.get_session_statuses(moodle_token, session_id)
+
+    unless session_statuses.is_a?(Array) && session_statuses.any?
+      Resque.logger.error "[MoodleAttendanceJob] Failed to retrieve session statuses for session ID #{session_id}."
+      return { presence_status_id: nil, absence_status_id: nil, partial_status_id: nil }
+    end
+
+    valid_statuses = session_statuses.select { |s| s.is_a?(Hash) && s.key?(:id) && s.key?(:grade) }
+                                     .map { |s| s.merge(grade: s[:grade].to_f) }
+
+    if valid_statuses.empty?
+      Resque.logger.error "[MoodleAttendanceJob] No valid statuses with ID/grade for session ID #{session_id}."
+      return { presence_status_id: nil, absence_status_id: nil, partial_status_id: nil }
+    end
+
+    # one entry per distinct grade, sorted from highest to lowest
+    by_grade_desc = valid_statuses.uniq { |s| s[:grade] }.sort_by { |s| -s[:grade] }
+
+    presence_status_id = by_grade_desc.first[:id]
+    absence_status_id  = by_grade_desc.last[:id]
+    # partial status only exists if there are at least 3 distinct grades
+    partial_status_id  = by_grade_desc.length >= 3 ? by_grade_desc[1][:id] : nil
+
+    Resque.logger.info "[MoodleAttendanceJob] session=#{session_id} presence=#{presence_status_id} " \
+                        "partial=#{partial_status_id.inspect} absence=#{absence_status_id} " \
+                        "(#{by_grade_desc.length} distinct grades found)"
+
+    { presence_status_id: presence_status_id, absence_status_id: absence_status_id, partial_status_id: partial_status_id }
   end
 
   def mark_attendance_for_users(moodle_token, session_id, presence_status_id, absence_status_id, conference_data, course_id)
@@ -285,5 +344,100 @@ class MoodleAttendanceJob < ApplicationJob
     end
 
     Resque.logger.info "[MoodleAttendanceJob] Attendance marking summary for session ID #{session_id} - Present (Success: #{present_marked_count}, Failed: #{present_failed_count}), Absent (Success: #{absent_marked_count}, Failed: #{absent_failed_count})."
+  end
+
+  def mark_attendance_for_users_by_percentage(moodle_token, session_id, status_ids, conference_data, course_id)
+    conference_attendees_data = conference_data.dig('data', 'attendees')
+    unless conference_attendees_data.is_a?(Array)
+      Resque.logger.error "[MoodleAttendanceJob] Conference attendees data is missing or not an array."
+      return
+    end
+
+    meeting_duration = conference_data.dig('data', 'duration').to_i
+    threshold = moodle_token.presence_threshold_percentage.to_f
+    partial_threshold = moodle_token.partial_presence_threshold_percentage.to_f
+
+    first_moderator = conference_attendees_data.find { |att| att['moderator'] == true }
+    unless first_moderator && first_moderator['ext_user_id'].present?
+      Resque.logger.error "[MoodleAttendanceJob] Could not find a moderator with ext_user_id to use as 'takenbyid'."
+      return
+    end
+    taken_by_id = first_moderator['ext_user_id']
+    status_set_param = 0
+
+    # ext_user_id => { status_id:, percentage: }
+    result_by_user = {}
+
+    conference_attendees_data.each do |att|
+      student_id = att['ext_user_id']&.to_i
+      next unless student_id
+
+      percentage = attendee_percentage(att, meeting_duration)
+
+      status_id =
+        if percentage.nil?
+          # duration missing/invalid in payload: binary fallback -- present, since they are in the attendees list
+          Resque.logger.warn "[MoodleAttendanceJob] `duration` missing/invalid in payload for ext_user_id=#{student_id}, session=#{session_id}. Applying fallback binary (Present)."
+          status_ids[:presence_status_id]
+        elsif percentage <= 0
+          status_ids[:absence_status_id]
+        elsif percentage >= threshold
+          status_ids[:presence_status_id]
+        elsif percentage >= partial_threshold
+          # partial_threshold <= percentage < threshold: eligible for partial presence
+          status_ids[:partial_status_id] || status_ids[:absence_status_id]
+        else
+          # 0 < percentage < partial_threshold: attended, but not enough to be eligible for partial presence
+          status_ids[:absence_status_id]
+        end
+
+      result_by_user[student_id] = { status_id: status_id, percentage: percentage }
+    end
+
+    # users enrolled but not appearing in the attendees list are considered absent (0% attendance)
+    all_moodle_user_ids = Moodle::API.get_enrolled_user_ids(moodle_token, course_id)
+    if all_moodle_user_ids.nil?
+      Resque.logger.error "[MoodleAttendanceJob] Failed to retrieve enrolled users for course ID #{course_id}."
+    else
+      (all_moodle_user_ids - result_by_user.keys).each do |student_id|
+        result_by_user[student_id] = { status_id: status_ids[:absence_status_id], percentage: 0 }
+      end
+    end
+
+    # every user in result_by_user must be recorded (no enrolled student can remain without a status)
+    result_by_user.each do |student_id, result|
+      status_id = result[:status_id]
+      success = Moodle::API.update_user_status(moodle_token, session_id, student_id, taken_by_id, status_id, status_set_param)
+      log_percentage_attendance_result(session_id, student_id, status_id, status_ids, result[:percentage], success)
+    end
+  end
+
+  def log_percentage_attendance_result(session_id, student_id, status_id, status_ids, percentage, success)
+    label =
+      if status_id == status_ids[:presence_status_id]
+        'PRESENT'
+      elsif status_ids[:partial_status_id] && status_id == status_ids[:partial_status_id]
+        'PARTIAL PRESENT'
+      else
+        'ABSENT'
+      end
+
+    percentage_label = percentage.nil? ? 'unknown' : "#{percentage}%"
+    action = success ? 'Successfully marked' : 'Failed to mark'
+
+    Resque.logger.public_send(success ? :info : :error,
+      "[MoodleAttendanceJob] #{action} #{label} (percentage #{percentage_label}) for student ID #{student_id} in session ID #{session_id}.")
+  end
+
+  def attendee_percentage(attendee, meeting_duration)
+    return nil unless meeting_duration.positive?
+
+    raw_duration = attendee['duration']
+    return nil if raw_duration.nil?
+
+    duration = raw_duration.to_f
+    return nil if duration.negative?
+
+    [((duration / meeting_duration) * 100).round(2), 100.0].min
   end
 end

--- a/app/jobs/moodle_attendance_job.rb
+++ b/app/jobs/moodle_attendance_job.rb
@@ -266,8 +266,11 @@ class MoodleAttendanceJob < ApplicationJob
       return { presence_status_id: nil, absence_status_id: nil, partial_status_id: nil }
     end
 
-    # one entry per distinct grade, sorted from highest to lowest
-    by_grade_desc = valid_statuses.uniq { |s| s[:grade] }.sort_by { |s| -s[:grade] }
+    # One entry per distinct grade, sorted from highest to lowest. Statuses sharing a grade are
+    # broken by id, so the oldest one wins: Moodle creates the default set in the order Present,
+    # Absent, Late, Excused, and Late and Excused share the same grade. Sorting before uniq also
+    # keeps the choice from depending on the order the API happened to return.
+    by_grade_desc = valid_statuses.sort_by { |s| [-s[:grade], s[:id].to_i] }.uniq { |s| s[:grade] }
 
     presence_status_id = by_grade_desc.first[:id]
     absence_status_id  = by_grade_desc.last[:id]

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -28,7 +28,11 @@ class Room < ApplicationRecord
     Moodle::API.token_functions_configured?(moodle_token, ['core_calendar_delete_calendar_events'])
   end
 
+  # Memoized because it hits the Moodle API, and it is asked more than once per request
+  # (the scheduled meeting form needs it for both the checkbox and its tooltip)
   def can_mark_moodle_attendance
+    return @can_mark_moodle_attendance unless @can_mark_moodle_attendance.nil?
+
     moodle_token = self.consumer_config&.moodle_token
     required_functions = [
       'core_course_get_contents',
@@ -38,7 +42,7 @@ class Room < ApplicationRecord
       'mod_attendance_get_session',
       'mod_attendance_update_user_status'
     ]
-    Moodle::API.token_functions_configured?(moodle_token, required_functions)
+    @can_mark_moodle_attendance = Moodle::API.token_functions_configured?(moodle_token, required_functions)
   end
 
   def moodle_attendance_tooltip_key

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -41,6 +41,12 @@ class Room < ApplicationRecord
     Moodle::API.token_functions_configured?(moodle_token, required_functions)
   end
 
+  def moodle_attendance_tooltip_key
+    return :mark_moodle_attendance_disabled unless can_mark_moodle_attendance
+
+    moodle_token&.presence_percentage_enabled? ? :mark_moodle_attendance_percentage : :mark_moodle_attendance
+  end
+
   def brightspace_oauth?
     self.consumer_config&.brightspace_oauth.present?
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,7 +140,7 @@ en:
         allmoderators: "All users will join as moderators"
         create_moodle_calendar_event: "Create a corresponding event in the Moodle Calendar for this scheduled meeting."
         disable_replicate_in_moodle_calendar: "There are no events in the Moodle Calendar corresponding to this scheduled meeting."
-        mark_moodle_attendance: "If checked, the meeting will mark the attendance status (present or absent) on the first Attendance Moodle activity for every user on this course. If there is no Attendance Moodle activity, one will be created."
+        mark_moodle_attendance: "If checked, the meeting will mark the attendance status in the first Attendance Moodle activity for every user on this course, based on the attendance percentage. If there is no Attendance Moodle activity, one will be created."
         replicate_in_moodle_calendar: "The changes will be applied to the events in the Moodle Calendar corresponding to that scheduled meeting."
       updated:        "The session schedule was updated"
       wait:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,7 +140,8 @@ en:
         allmoderators: "All users will join as moderators"
         create_moodle_calendar_event: "Create a corresponding event in the Moodle Calendar for this scheduled meeting."
         disable_replicate_in_moodle_calendar: "There are no events in the Moodle Calendar corresponding to this scheduled meeting."
-        mark_moodle_attendance: "If checked, the meeting will mark the attendance status in the first Attendance Moodle activity for every user on this course, based on the attendance percentage. If there is no Attendance Moodle activity, one will be created."
+        mark_moodle_attendance: "If checked, the meeting will mark the attendance status (present or absent) on the first Attendance Moodle activity for every user on this course. If there is no Attendance Moodle activity, one will be created."
+        mark_moodle_attendance_percentage: "If checked, the meeting will mark the attendance status in the first Attendance Moodle activity for every user on this course, based on the attendance percentage. If there is no Attendance Moodle activity, one will be created."
         replicate_in_moodle_calendar: "The changes will be applied to the events in the Moodle Calendar corresponding to that scheduled meeting."
       updated:        "The session schedule was updated"
       wait:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -109,7 +109,8 @@ es:
         allmoderators: "Todos los usuarios serán moderadores"
         create_moodle_calendar_event: "Cree un evento correspondiente en el Calendario de Moodle para esta reunión programada."
         disable_replicate_in_moodle_calendar: "No hay eventos en el Calendario de Moodle correspondientes a esta reunión programada."
-        mark_moodle_attendance: "Si está marcada, la reunión registrará el estado de asistencia en la primera actividad de Asistencia de Moodle para cada usuario en este curso, basado en el porcentaje de asistencia. Si no existe una actividad de Asistencia en Moodle, se creará una."
+        mark_moodle_attendance: "Si está marcada, la reunión registrará el estado de asistencia (presente o ausente) en la primera actividad de Asistencia de Moodle para cada usuario en este curso. Si no existe una actividad de Asistencia en Moodle, se creará una."
+        mark_moodle_attendance_percentage: "Si está marcada, la reunión registrará el estado de asistencia en la primera actividad de Asistencia de Moodle para cada usuario en este curso, basado en el porcentaje de asistencia. Si no existe una actividad de Asistencia en Moodle, se creará una."
         replicate_in_moodle_calendar: "Los cambios se aplicarán a los eventos del Calendario de Moodle correspondientes a esa reunión programada."
       updated:        "La programación ha sido actualizada"
       wait:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -109,7 +109,7 @@ es:
         allmoderators: "Todos los usuarios serán moderadores"
         create_moodle_calendar_event: "Cree un evento correspondiente en el Calendario de Moodle para esta reunión programada."
         disable_replicate_in_moodle_calendar: "No hay eventos en el Calendario de Moodle correspondientes a esta reunión programada."
-        mark_moodle_attendance: "Si está marcada, la reunión registrará el estado de asistencia (presente o ausente) en la primera actividad de Asistencia de Moodle para cada usuario en este curso. Si no existe una actividad de Asistencia en Moodle, se creará una."
+        mark_moodle_attendance: "Si está marcada, la reunión registrará el estado de asistencia en la primera actividad de Asistencia de Moodle para cada usuario en este curso, basado en el porcentaje de asistencia. Si no existe una actividad de Asistencia en Moodle, se creará una."
         replicate_in_moodle_calendar: "Los cambios se aplicarán a los eventos del Calendario de Moodle correspondientes a esa reunión programada."
       updated:        "La programación ha sido actualizada"
       wait:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -109,7 +109,7 @@ pt:
         allmoderators: "Todos usuários serão moderadores"
         create_moodle_calendar_event: "Cria um evento correspondente no Calendário do Moodle para esta sessão agendada."
         disable_replicate_in_moodle_calendar: "Não existem eventos no Calendário do Moodle correspondentes a essa sessão agendada."
-        mark_moodle_attendance: "Se marcado, a reunião registrará o status de presença (presente ou ausente) na primeira atividade de Presença do Moodle para cada usuário neste curso. Se não houver uma atividade de Presença no Moodle, uma será criada."
+        mark_moodle_attendance: "Se marcado, a reunião registrará o status de presença na primeira atividade de Presença do Moodle para cada usuário neste curso, baseado na porcentagem de presença. Se não houver uma atividade de Presença no Moodle, uma será criada."
         replicate_in_moodle_calendar: "As mudanças serão aplicadas aos eventos no Calendário do Moodle correspondentes a essa sessão agendada."
       updated:        "O agendamento foi atualizado"
       wait:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -109,7 +109,8 @@ pt:
         allmoderators: "Todos usuários serão moderadores"
         create_moodle_calendar_event: "Cria um evento correspondente no Calendário do Moodle para esta sessão agendada."
         disable_replicate_in_moodle_calendar: "Não existem eventos no Calendário do Moodle correspondentes a essa sessão agendada."
-        mark_moodle_attendance: "Se marcado, a reunião registrará o status de presença na primeira atividade de Presença do Moodle para cada usuário neste curso, baseado na porcentagem de presença. Se não houver uma atividade de Presença no Moodle, uma será criada."
+        mark_moodle_attendance: "Se marcado, a reunião registrará o status de presença (presente ou ausente) na primeira atividade de Presença do Moodle para cada usuário neste curso. Se não houver uma atividade de Presença no Moodle, uma será criada."
+        mark_moodle_attendance_percentage: "Se marcado, a reunião registrará o status de presença na primeira atividade de Presença do Moodle para cada usuário neste curso, baseado na porcentagem de presença. Se não houver uma atividade de Presença no Moodle, uma será criada."
         replicate_in_moodle_calendar: "As mudanças serão aplicadas aos eventos no Calendário do Moodle correspondentes a essa sessão agendada."
       updated:        "O agendamento foi atualizado"
       wait:

--- a/db/migrate/20260810201610_add_presence_percentage_fields_to_moodle_tokens.rb
+++ b/db/migrate/20260810201610_add_presence_percentage_fields_to_moodle_tokens.rb
@@ -1,0 +1,7 @@
+class AddPresencePercentageFieldsToMoodleTokens < ActiveRecord::Migration[8.0]
+  def change
+    add_column :moodle_tokens, :presence_percentage_enabled, :boolean, default: false, null: false
+    add_column :moodle_tokens, :presence_threshold_percentage, :integer, default: 75, null: false
+    add_column :moodle_tokens, :partial_presence_threshold_percentage, :integer, default: 10, null: false
+  end
+end

--- a/db/migrate/20260810201611_add_moodle_attendance_fields_to_scheduled_meetings.rb
+++ b/db/migrate/20260810201611_add_moodle_attendance_fields_to_scheduled_meetings.rb
@@ -1,0 +1,6 @@
+class AddMoodleAttendanceFieldsToScheduledMeetings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :scheduled_meetings, :moodle_attendance_session_id, :bigint
+    add_column :scheduled_meetings, :moodle_attendance_internal_meeting_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -122,7 +122,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_10_201611) do
     t.boolean "show_all_groups", default: true
     t.boolean "presence_percentage_enabled", default: false, null: false
     t.integer "presence_threshold_percentage", default: 75, null: false
-    t.integer "presence_partial_threshold_percentage", default: 10, null: false
+    t.integer "partial_presence_threshold_percentage", default: 10, null: false
     t.index ["consumer_config_id"], name: "index_moodle_tokens_on_consumer_config_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_29_223008) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_10_201611) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -120,6 +120,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_29_223008) do
     t.datetime "updated_at", null: false
     t.boolean "group_select_enabled", default: false
     t.boolean "show_all_groups", default: true
+    t.boolean "presence_percentage_enabled", default: false, null: false
+    t.integer "presence_threshold_percentage", default: 75, null: false
+    t.integer "presence_partial_threshold_percentage", default: 10, null: false
     t.index ["consumer_config_id"], name: "index_moodle_tokens_on_consumer_config_id"
   end
 
@@ -164,6 +167,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_29_223008) do
     t.boolean "mark_moodle_attendance"
     t.boolean "mark_brightspace_attendance", default: false, null: false
     t.datetime "last_meeting_date"
+    t.bigint "moodle_attendance_session_id"
+    t.string "moodle_attendance_internal_meeting_id"
     t.index ["created_by_launch_nonce"], name: "index_scheduled_meetings_on_created_by_launch_nonce"
     t.index ["hash_id"], name: "index_scheduled_meetings_on_hash_id", unique: true
     t.index ["repeat"], name: "index_scheduled_meetings_on_repeat"

--- a/spec/factories/moodle_token.rb
+++ b/spec/factories/moodle_token.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :moodle_token do |m|
+    m.token                          { Faker::Lorem.characters(number: 32) }
+    m.url                            { 'https://moodle.example.com/webservice/rest/server.php' }
+    m.group_select_enabled           { false }
+    m.show_all_groups                { true }
+    m.presence_percentage_enabled            { false }
+    m.presence_threshold_percentage          { 75 }
+    m.partial_presence_threshold_percentage  { 10 }
+    m.created_at                     { Time.zone.now }
+    m.updated_at                     { Time.zone.now }
+
+    association :consumer_config
+  end
+end

--- a/spec/jobs/moodle_attendance_job_spec.rb
+++ b/spec/jobs/moodle_attendance_job_spec.rb
@@ -222,6 +222,44 @@ RSpec.describe MoodleAttendanceJob, type: :job do
       end
     end
 
+    context 'when Late and Excused share the same grade (Moodle default status set)' do
+      # Moodle creates the default set in the order Present, Absent, Late, Excused, so Late always
+      # has the lower id, but both have grade 1 and the API may list them in any order. Only Late
+      # is meant to be used as partial presence: Excused means the teacher justified the absence.
+      let(:statuses_with_excused_first) do
+        [
+          { id: 10, description: 'Present', grade: 2 },
+          { id: 11, description: 'Absent',  grade: 0 },
+          { id: 13, description: 'Excused', grade: 1 },
+          { id: 12, description: 'Late',    grade: 1 }
+        ]
+      end
+
+      before do
+        allow(Moodle::API).to receive(:get_session_statuses).and_return(statuses_with_excused_first)
+      end
+
+      it 'records partial presence as Late even when Excused comes first in the response' do
+        # 200 -> 50%, between the partial and the full threshold
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 200, '999', 12, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+
+      it 'still resolves Present and Absent from the highest and lowest grades' do
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 100, '999', 10, 0
+        )
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 300, '999', 11, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+    end
+
     context 'when the total meeting duration is zero/missing' do
       let(:meeting_duration_seconds) { 0 }
 

--- a/spec/jobs/moodle_attendance_job_spec.rb
+++ b/spec/jobs/moodle_attendance_job_spec.rb
@@ -1,0 +1,474 @@
+require 'rails_helper'
+
+RSpec.describe MoodleAttendanceJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:theme) { 'elos' }
+  let(:locale) { 'en' }
+  let(:course_id) { '12345' }
+  let(:attendance_instance_id) { 500 }
+  let(:session_id) { 555 }
+
+  let(:room) { FactoryBot.create(:room) }
+  let(:scheduled_meeting) do
+    FactoryBot.create(:scheduled_meeting,
+           room: room,
+           name: 'Test Meeting',
+           start_at: Time.zone.now)
+  end
+
+  let!(:consumer_config) { FactoryBot.create(:consumer_config, key: 'test_consumer_key_123') }
+  let!(:moodle_token) do
+    FactoryBot.create(:moodle_token,
+           consumer_config: consumer_config,
+           token: 'moodle_token_abc',
+           url: 'https://moodle.example.com/webservice/rest/server.php')
+  end
+
+  let(:app_launch) do
+    launch = FactoryBot.create(:app_launch, nonce: 'test_nonce_123')
+    launch.params = {
+      'user_id' => 'prefix_999',
+      'context_id' => course_id,
+      'custom_params' => {
+        'oauth_consumer_key' => consumer_config.key
+      }
+    }
+    launch.save!
+    launch
+  end
+
+  let(:meeting_duration_seconds) { 3600 }
+  let(:internal_meeting_id) { 'internal-meeting-id-test-1' }
+
+  # Expected percentages (default threshold = 75%):
+  # 100 -> 3000/3600 = 83.33% => Present
+  # 200 -> 1800/3600 = 50.0%  => Partial presence (or Absent if no intermediate status)
+  # 300 -> 0/3600 = 0%        => Absent
+  # 400 -> no 'duration'     => binary fallback (Present) + warning
+  # 500 -> never appears in attendees => Absent (enrolled but did not attend)
+  let(:conference_data) do
+    {
+      'data' => {
+        'metadata' => {
+          'bbb_meeting_db_id' => scheduled_meeting.id.to_s,
+          'bbb_launch_nonce' => app_launch.nonce,
+          'bbb_oauth_consumer_key' => consumer_config.key
+        },
+        'start' => '2026-01-13T10:00:00Z',
+        'duration' => meeting_duration_seconds,
+        'attendees' => [
+          { 'ext_user_id' => '999', 'moderator' => true, 'duration' => 3600 },
+          { 'ext_user_id' => '100', 'moderator' => false, 'duration' => 3000 },
+          { 'ext_user_id' => '200', 'moderator' => false, 'duration' => 1800 },
+          { 'ext_user_id' => '300', 'moderator' => false, 'duration' => 0 },
+          { 'ext_user_id' => '400', 'moderator' => false }
+        ]
+      },
+      # top-level, sibling of 'data' -- matches the real BBB webhook payload shape.
+      # Uniquely identifies a real meeting instance (unlike scheduled_meeting_id, which recurring
+      # meetings reuse across every occurrence).
+      'internal_meeting_id' => internal_meeting_id
+    }
+  end
+
+  let(:conference_data_json) { conference_data.to_json }
+
+  let(:enrolled_user_ids) { [100, 200, 300, 400, 500] }
+
+  let(:two_statuses) do
+    [
+      { id: 1, description: 'Present', grade: 2 },
+      { id: 2, description: 'Absent', grade: 0 }
+    ]
+  end
+
+  let(:four_statuses) do
+    [
+      { id: 1, description: 'Present', grade: 2 },
+      { id: 2, description: 'Late', grade: 1 },
+      { id: 3, description: 'Excused', grade: 1 },
+      { id: 4, description: 'Absent', grade: 0 }
+    ]
+  end
+
+  before do
+    allow(Resque.logger).to receive(:info)
+    allow(Resque.logger).to receive(:error)
+    allow(Resque.logger).to receive(:warn)
+
+    allow(Moodle::API).to receive(:get_course_attendance_instances)
+      .and_return([{ instance: attendance_instance_id, name: 'Presença' }])
+    allow(Moodle::API).to receive(:get_session).and_return(nil)
+    allow(Moodle::API).to receive(:add_session).and_return(session_id)
+    allow(Moodle::API).to receive(:update_user_status).and_return(true)
+    allow(Moodle::API).to receive(:get_enrolled_user_ids).and_return(enrolled_user_ids)
+  end
+
+  describe '#perform with the feature flag disabled (legacy binary behavior)' do
+    before do
+      moodle_token.update!(presence_percentage_enabled: false)
+      allow(Moodle::API).to receive(:get_session_statuses).and_return(two_statuses)
+    end
+
+    it 'marks everyone in attendees as Present regardless of duration' do
+      %w[999 100 200 300 400].each do |ext_user_id|
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, ext_user_id.to_i, '999', 1, 0
+        )
+      end
+
+      described_class.perform_now(conference_data_json, theme, locale)
+    end
+
+    it 'marks enrolled users who are not in attendees as Absent' do
+      expect(Moodle::API).to receive(:update_user_status).with(
+        moodle_token, session_id, 500, '999', 2, 0
+      )
+
+      described_class.perform_now(conference_data_json, theme, locale)
+    end
+
+    it 'does not log any percentage-related warning' do
+      expect(Resque.logger).not_to receive(:warn).with(/duration.*missing\/invalid/)
+
+      described_class.perform_now(conference_data_json, theme, locale)
+    end
+  end
+
+  describe '#perform with the feature flag enabled (percentage-based attendance)' do
+    before do
+      moodle_token.update!(presence_percentage_enabled: true, presence_threshold_percentage: 75)
+    end
+
+    context 'when the activity has an intermediate status available' do
+      before do
+        allow(Moodle::API).to receive(:get_session_statuses).and_return(four_statuses)
+      end
+
+      it 'marks a user with percentage >= threshold as Present' do
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 100, '999', 1, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+
+      it 'marks a user with 0% < percentage < threshold as Presença parcial' do
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 200, '999', 2, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+
+      it 'marks a user with percentage == 0 as Absent' do
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 300, '999', 4, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+
+      it 'marks an enrolled user who never joined as Absent' do
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 500, '999', 4, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+
+      it 'falls back to Present and logs a warning when duration is missing for an attendee' do
+        expect(Resque.logger).to receive(:warn).with(
+          /`duration` missing\/invalid in payload for ext_user_id=400/
+        )
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 400, '999', 1, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+
+      it 'satisfies the gradebook invariant: every enrolled user gets some status' do
+        enrolled_user_ids.each do |uid|
+          expect(Moodle::API).to receive(:update_user_status).with(
+            moodle_token, session_id, uid, '999', anything, 0
+          )
+        end
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+    end
+
+    context 'when the activity only has 2 distinct statuses (no intermediate one)' do
+      before do
+        allow(Moodle::API).to receive(:get_session_statuses).and_return(two_statuses)
+      end
+
+      it 'falls back to Absent for a user with 0% < percentage < threshold' do
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 200, '999', 2, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+
+      it 'still marks a user with percentage >= threshold as Present' do
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 100, '999', 1, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+    end
+
+    context 'when the total meeting duration is zero/missing' do
+      let(:meeting_duration_seconds) { 0 }
+
+      before do
+        allow(Moodle::API).to receive(:get_session_statuses).and_return(four_statuses)
+      end
+
+      it 'falls back to the binary behavior (Present) for everyone in attendees' do
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 100, '999', 1, 0
+        )
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 200, '999', 1, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+    end
+
+    context 'when an attendee duration slightly exceeds the meeting duration (clock skew)' do
+      let(:conference_data) do
+        data = super()
+        # 900 -> 3700/3600 = 102.78% before clamping -- should be capped at 100%
+        data['data']['attendees'] << { 'ext_user_id' => '900', 'moderator' => false, 'duration' => 3700 }
+        data
+      end
+      let(:enrolled_user_ids) { [100, 200, 300, 400, 500, 900] }
+
+      before do
+        allow(Moodle::API).to receive(:get_session_statuses).and_return(four_statuses)
+      end
+
+      it 'clamps the percentage to 100% instead of logging a value above 100' do
+        job = described_class.new
+        attendee = { 'duration' => 3700 }
+
+        expect(job.send(:attendee_percentage, attendee, 3600)).to eq(100.0)
+      end
+
+      it 'still marks the user as Present' do
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 900, '999', 1, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+    end
+
+    context 'when the threshold is customized per institution' do
+      before do
+        moodle_token.update!(presence_threshold_percentage: 40)
+        allow(Moodle::API).to receive(:get_session_statuses).and_return(four_statuses)
+      end
+
+      it 'marks a user above the custom threshold as Present instead of Partial' do
+        # 200 -> 50% >= 40% (custom threshold) => Present
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 200, '999', 1, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+    end
+
+    context 'when the partial threshold is left at its default (not explicitly configured)' do
+      let(:conference_data) do
+        data = super()
+        # 800 -> 150/3600 = 4.17% (below the real default of 10%)
+        data['data']['attendees'] << { 'ext_user_id' => '800', 'moderator' => false, 'duration' => 150 }
+        data
+      end
+      let(:enrolled_user_ids) { [100, 200, 300, 400, 500, 800] }
+
+      before do
+        allow(Moodle::API).to receive(:get_session_statuses).and_return(four_statuses)
+      end
+
+      it 'defaults partial_presence_threshold_percentage to 10' do
+        expect(moodle_token.partial_presence_threshold_percentage).to eq(10)
+      end
+
+      it 'marks a user below the default 10% partial threshold as Absent, not Partial' do
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 800, '999', 4, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+    end
+
+    context 'when a minimum partial-presence threshold is configured' do
+      let(:conference_data) do
+        data = super()
+        # 600 -> 90/3600 = 2.5%  (below the 30% partial threshold)
+        # 700 -> 1080/3600 = 30% (exactly at the partial threshold)
+        data['data']['attendees'] << { 'ext_user_id' => '600', 'moderator' => false, 'duration' => 90 }
+        data['data']['attendees'] << { 'ext_user_id' => '700', 'moderator' => false, 'duration' => 1080 }
+        data
+      end
+      let(:enrolled_user_ids) { [100, 200, 300, 400, 500, 600, 700] }
+
+      before do
+        moodle_token.update!(partial_presence_threshold_percentage: 30)
+        allow(Moodle::API).to receive(:get_session_statuses).and_return(four_statuses)
+      end
+
+      it 'marks a user below the partial threshold (but above 0%) as Absent instead of Partial' do
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 600, '999', 4, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+
+      it 'marks a user exactly at the partial threshold as Partial' do
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 700, '999', 2, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+
+      it 'still marks a user between the partial threshold and the full threshold as Partial' do
+        # 200 -> 50% is between 30% (partial) and 75% (full) => Partial
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 200, '999', 2, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+
+      it 'still marks a user at/above the full threshold as Present' do
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 100, '999', 1, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+
+      it 'still marks a user with percentage == 0 as Absent, not Partial' do
+        # partial_threshold defaults would not apply here: 0% is always Absent regardless
+        expect(Moodle::API).to receive(:update_user_status).with(
+          moodle_token, session_id, 300, '999', 4, 0
+        )
+
+        described_class.perform_now(conference_data_json, theme, locale)
+      end
+    end
+  end
+
+  describe 'idempotency of Moodle session creation' do
+    before do
+      allow(Moodle::API).to receive(:get_session_statuses).and_return(two_statuses)
+    end
+
+    it 'creates a new session and stores its id and internal_meeting_id on the first run' do
+      described_class.perform_now(conference_data_json, theme, locale)
+
+      expect(Moodle::API).to have_received(:add_session).once
+      scheduled_meeting.reload
+      expect(scheduled_meeting.moodle_attendance_session_id).to eq(session_id)
+      expect(scheduled_meeting.moodle_attendance_internal_meeting_id).to eq(internal_meeting_id)
+    end
+
+    it 'reuses the stored session id on a retry of the SAME occurrence (same internal_meeting_id)' do
+      described_class.perform_now(conference_data_json, theme, locale)
+
+      allow(Moodle::API).to receive(:get_session).with(moodle_token, session_id).and_return(
+        { 'id' => session_id, 'statuses' => two_statuses }
+      )
+
+      described_class.perform_now(conference_data_json, theme, locale)
+
+      expect(Moodle::API).to have_received(:add_session).once
+    end
+
+    it 'creates a new session if the previously stored one no longer exists on Moodle' do
+      described_class.perform_now(conference_data_json, theme, locale)
+
+      allow(Moodle::API).to receive(:get_session).with(moodle_token, session_id).and_return(nil)
+      allow(Moodle::API).to receive(:add_session).and_return(556)
+
+      described_class.perform_now(conference_data_json, theme, locale)
+
+      expect(Moodle::API).to have_received(:add_session).twice
+      expect(scheduled_meeting.reload.moodle_attendance_session_id).to eq(556)
+    end
+
+    # Regression test: a recurring ScheduledMeeting reuses the SAME scheduled_meeting_id across
+    # every occurrence (week 1, week 2, ...). Before this fix, idempotency was keyed only by
+    # scheduled_meeting_id, so a second, entirely different real meeting would incorrectly reuse
+    # (and silently overwrite) the first occurrence's Moodle session.
+    it 'creates a NEW session -- and does not overwrite the previous one -- for a different occurrence of a recurring meeting (different internal_meeting_id)' do
+      described_class.perform_now(conference_data_json, theme, locale)
+      expect(scheduled_meeting.reload.moodle_attendance_session_id).to eq(session_id)
+
+      # the first occurrence's session is still technically valid on Moodle...
+      allow(Moodle::API).to receive(:get_session).with(moodle_token, session_id).and_return(
+        { 'id' => session_id, 'statuses' => two_statuses }
+      )
+      allow(Moodle::API).to receive(:add_session).and_return(556)
+
+      next_occurrence_data = conference_data.dup
+      next_occurrence_data['internal_meeting_id'] = 'internal-meeting-id-test-2-different-occurrence'
+
+      described_class.perform_now(next_occurrence_data.to_json, theme, locale)
+
+      expect(Moodle::API).to have_received(:add_session).twice
+      scheduled_meeting.reload
+      expect(scheduled_meeting.moodle_attendance_session_id).to eq(556)
+      expect(scheduled_meeting.moodle_attendance_internal_meeting_id).to eq('internal-meeting-id-test-2-different-occurrence')
+    end
+
+    it 'never reuses a stored session when internal_meeting_id is missing from the payload (defensive fallback)' do
+      described_class.perform_now(conference_data_json, theme, locale)
+
+      data_without_internal_id = conference_data.dup
+      data_without_internal_id.delete('internal_meeting_id')
+      allow(Moodle::API).to receive(:add_session).and_return(557)
+
+      described_class.perform_now(data_without_internal_id.to_json, theme, locale)
+
+      expect(Moodle::API).to have_received(:add_session).twice
+    end
+  end
+
+  describe '#perform with invalid/missing top-level data' do
+    it 'logs error and returns early when bbb_meeting_db_id is missing' do
+      data = conference_data.dup
+      data['data']['metadata'].delete('bbb_meeting_db_id')
+
+      expect(Resque.logger).to receive(:error).with(
+        /Could not find 'bbb_meeting_db_id' in conference_data metadata/
+      )
+
+      described_class.perform_now(data.to_json, theme, locale)
+    end
+
+    it 'logs error and returns early when ConsumerConfig cannot be found' do
+      data = conference_data.dup
+      data['data']['metadata']['bbb_oauth_consumer_key'] = 'nonexistent_key'
+
+      expect(Resque.logger).to receive(:error).with(
+        /Could not find ConsumerConfig with key 'nonexistent_key'/
+      )
+
+      described_class.perform_now(data.to_json, theme, locale)
+    end
+  end
+end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -7,4 +7,49 @@ RSpec.describe Room, type: :model do
     expect(FactoryBot.build(:room)).to be_valid
   end
 
+  describe '#can_mark_moodle_attendance' do
+    let(:room) { FactoryBot.create(:room) }
+
+    it 'asks the Moodle API only once per instance' do
+      expect(Moodle::API).to receive(:token_functions_configured?).once.and_return(true)
+
+      room.can_mark_moodle_attendance
+      room.can_mark_moodle_attendance
+      room.moodle_attendance_tooltip_key
+    end
+
+    it 'memoizes a negative answer as well' do
+      expect(Moodle::API).to receive(:token_functions_configured?).once.and_return(false)
+
+      expect(room.can_mark_moodle_attendance).to be(false)
+      expect(room.can_mark_moodle_attendance).to be(false)
+    end
+  end
+
+  describe '#moodle_attendance_tooltip_key' do
+    let(:consumer_config) { FactoryBot.create(:consumer_config, key: 'room-spec-consumer-key') }
+    let(:room) { FactoryBot.create(:room, consumer_key: consumer_config.key) }
+    let!(:moodle_token) { FactoryBot.create(:moodle_token, consumer_config: consumer_config) }
+
+    it 'returns the disabled key when attendance cannot be marked' do
+      allow(Moodle::API).to receive(:token_functions_configured?).and_return(false)
+
+      expect(room.moodle_attendance_tooltip_key).to eq(:mark_moodle_attendance_disabled)
+    end
+
+    it 'returns the percentage key when the institution has the feature enabled' do
+      allow(Moodle::API).to receive(:token_functions_configured?).and_return(true)
+      moodle_token.update!(presence_percentage_enabled: true)
+
+      expect(room.moodle_attendance_tooltip_key).to eq(:mark_moodle_attendance_percentage)
+    end
+
+    it 'returns the binary key when the institution does not have the feature enabled' do
+      allow(Moodle::API).to receive(:token_functions_configured?).and_return(true)
+      moodle_token.update!(presence_percentage_enabled: false)
+
+      expect(room.moodle_attendance_tooltip_key).to eq(:mark_moodle_attendance)
+    end
+  end
+
 end

--- a/themes/elos/views/scheduled_meetings/_form.html.erb
+++ b/themes/elos/views/scheduled_meetings/_form.html.erb
@@ -140,7 +140,7 @@
               disabled: !can_mark_moodle_attendance %>
             <%= form.label :mark_moodle_attendance, class: "form-check-label" do %>
               <%= t('helpers.label.scheduled_meeting.mark_moodle_attendance') %>
-              <i class="icon material-icons icon-label-hint" data-bs-toggle="tooltip" title="<%= can_mark_moodle_attendance ? t('default.scheduled_meeting.tooltip.mark_moodle_attendance') : t('default.scheduled_meeting.tooltip.mark_moodle_attendance_disabled') %>">help</i>
+              <i class="icon material-icons icon-label-hint" data-bs-toggle="tooltip" title="<%= t("default.scheduled_meeting.tooltip.#{@room.moodle_attendance_tooltip_key}") %>">help</i>
             <% end %>
           </div>
         </div>

--- a/themes/rnp/views/scheduled_meetings/_form.html.erb
+++ b/themes/rnp/views/scheduled_meetings/_form.html.erb
@@ -122,7 +122,7 @@
                 disabled: !can_mark_attendance %>
             <%= form.label :mark_moodle_attendance, class: "form-check-label" do %>
               <%= t('helpers.label.scheduled_meeting.mark_moodle_attendance') %>
-              <i class="icon material-icons icon-label-hint" data-bs-toggle="tooltip" title="<%= can_mark_attendance ? t('default.scheduled_meeting.tooltip.mark_moodle_attendance') : t('default.scheduled_meeting.tooltip.mark_moodle_attendance_disabled') %>">help</i>
+              <i class="icon material-icons icon-label-hint" data-bs-toggle="tooltip" title="<%= t("default.scheduled_meeting.tooltip.#{@room.moodle_attendance_tooltip_key}") %>">help</i>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
## Summary
  - Adds `presence_percentage_enabled`, `presence_threshold_percentage` and `partial_presence_threshold_percentage` to `MoodleToken`, controlling a per-institution feature flag and two thresholds (full presence / partial presence) used to classify each user as **Present, Partial presence, or Absent** based on their real participation time in the meeting.
  - Partial presence is recorded on Moodle by reusing an existing intermediate-grade status already configured on the `mod_attendance` activity (typically "Late") — no new status is created via API.
  - Attendance-session idempotency is now scoped by `internal_meeting_id` (the BBB identifier for the real meeting instance), not just `scheduled_meeting_id`, so recurring meetings get one Moodle session per real occurrence instead of overwriting the same session every time.