### PR TITLE
[PRT-2722] feat: auto start recording config

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -427,7 +427,8 @@ class RoomsController < ApplicationController
       institution_guid: custom_params['institution_guid'],
       allow_student_scheduling: custom_params['allow_student_scheduling'],
       allow_ai_artifacts: custom_params['allow_ai_artifacts'],
-      hide_recordings_history: custom_params['hide_recordings_history']
+      hide_recordings_history: custom_params['hide_recordings_history'],
+      auto_start_recording: custom_params['auto_start_recording']
     )
     Rails.logger.info "[setup_consumer_configs] ConsumerConfig created/updated with key=#{@consumer_config.key}, " \
     "params=#{custom_params.except('bbb', 'moodle', 'brightspace')}"

--- a/app/controllers/scheduled_meetings_controller.rb
+++ b/app/controllers/scheduled_meetings_controller.rb
@@ -556,6 +556,7 @@ class ScheduledMeetingsController < ApplicationController
     ]
     attrs << [:wait_moderator] if room.allow_wait_moderator
     attrs << [:all_moderators] if room.allow_all_moderators
+    attrs << [:auto_start_recording] if room.auto_start_recording
     params.require(:scheduled_meeting).permit(*attrs)
   end
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -70,6 +70,10 @@ class Room < ApplicationRecord
     ConsumerConfig.find_by(key: self.consumer_key)
   end
 
+  def auto_start_recording
+    self.consumer_config&.auto_start_recording || false
+  end
+
   def moodle_token
     consumer_config&.moodle_token
   end
@@ -102,7 +106,8 @@ class Room < ApplicationRecord
     {
       recording: self.recording,
       all_moderators: self.all_moderators,
-      wait_moderator: self.wait_moderator
+      wait_moderator: self.wait_moderator,
+      auto_start_recording: self.auto_start_recording
     }
   end
 

--- a/app/models/scheduled_meeting.rb
+++ b/app/models/scheduled_meeting.rb
@@ -122,6 +122,10 @@ class ScheduledMeeting < ApplicationRecord
     recurring? && repeat == "every_two_weeks"
   end
 
+  def will_auto_start_recording?(room = self.room)
+    self.recording && self.auto_start_recording && room.auto_start_recording
+  end
+
   def replicated_in_moodle?
     MoodleCalendarEvent.where(scheduled_meeting_hash_id: self.hash_id).any?
   end
@@ -149,7 +153,7 @@ class ScheduledMeeting < ApplicationRecord
       attendeePW: self.room.viewer,
       welcome: self.welcome,
       record: self.recording,
-      autoStartRecording: self.recording && self.auto_start_recording && self.room.auto_start_recording,
+      autoStartRecording: self.will_auto_start_recording?,
       lockSettingsDisablePrivateChat: self.disable_private_chat,
       lockSettingsDisableNote: self.disable_note
     }

--- a/app/models/scheduled_meeting.rb
+++ b/app/models/scheduled_meeting.rb
@@ -149,6 +149,7 @@ class ScheduledMeeting < ApplicationRecord
       attendeePW: self.room.viewer,
       welcome: self.welcome,
       record: self.recording,
+      autoStartRecording: self.recording && self.auto_start_recording && self.room.auto_start_recording,
       lockSettingsDisablePrivateChat: self.disable_private_chat,
       lockSettingsDisableNote: self.disable_note
     }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,6 +141,7 @@ en:
         recording:    "The session may be recorded"
         auto_start_recording: "The session will start recording automatically when the first participant joins"
         auto_start_recording_disabled: "Your institution has not enabled automatic recording start. To use this feature, contact your institution's administrator."
+        auto_start_recording_requires_recording: "To start recording automatically, the session must allow recording."
         waitmoderator: "Viewers are unable to join until a moderator joins"
         allmoderators: "All users will join as moderators"
         create_moodle_calendar_event: "Create a corresponding event in the Moodle Calendar for this scheduled meeting."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,6 +139,8 @@ en:
         every_two_weeks: "Biweekly"
       tooltip:
         recording:    "The session may be recorded"
+        auto_start_recording: "The session will start recording automatically when the first participant joins"
+        auto_start_recording_disabled: "Your institution has not enabled automatic recording start. To use this feature, contact your institution's administrator."
         waitmoderator: "Viewers are unable to join until a moderator joins"
         allmoderators: "All users will join as moderators"
         create_moodle_calendar_event: "Create a corresponding event in the Moodle Calendar for this scheduled meeting."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -108,6 +108,8 @@ es:
         every_two_weeks: "Quincenal"
       tooltip:
         recording:    "La sesión se puede grabar"
+        auto_start_recording: "La sesión comenzará a grabarse automáticamente cuando el primer participante se una"
+        auto_start_recording_disabled: "Su institución no ha habilitado el inicio automático de la grabación. Para usar esta función, comuníquese con el administrador de su institución."
         waitmoderator: "Los participantes no pueden ingresar hasta que ingrese un moderador"
         allmoderators: "Todos los usuarios serán moderadores"
         create_moodle_calendar_event: "Cree un evento correspondiente en el Calendario de Moodle para esta reunión programada."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -110,6 +110,7 @@ es:
         recording:    "La sesión se puede grabar"
         auto_start_recording: "La sesión comenzará a grabarse automáticamente cuando el primer participante se una"
         auto_start_recording_disabled: "Su institución no ha habilitado el inicio automático de la grabación. Para usar esta función, comuníquese con el administrador de su institución."
+        auto_start_recording_requires_recording: "Para iniciar la grabación automáticamente, la sesión debe permitir la grabación."
         waitmoderator: "Los participantes no pueden ingresar hasta que ingrese un moderador"
         allmoderators: "Todos los usuarios serán moderadores"
         create_moodle_calendar_event: "Cree un evento correspondiente en el Calendario de Moodle para esta reunión programada."

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -108,6 +108,8 @@ pt:
         every_two_weeks: "Quinzenal"
       tooltip:
         recording:    "A sessão poderá ser gravada"
+        auto_start_recording: "A sessão começará a ser gravada automaticamente quando o primeiro participante entrar"
+        auto_start_recording_disabled: "Sua instituição não habilitou o início automático da gravação. Para usar esse recurso, entre em contato com o administrador da sua instituição."
         waitmoderator: "Participantes não podem entrar até que um moderador entre"
         allmoderators: "Todos usuários serão moderadores"
         create_moodle_calendar_event: "Cria um evento correspondente no Calendário do Moodle para esta sessão agendada."

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -110,6 +110,7 @@ pt:
         recording:    "A sessão poderá ser gravada"
         auto_start_recording: "A sessão começará a ser gravada automaticamente quando o primeiro participante entrar"
         auto_start_recording_disabled: "Sua instituição não habilitou o início automático da gravação. Para usar esse recurso, entre em contato com o administrador da sua instituição."
+        auto_start_recording_requires_recording: "Para iniciar a gravação automaticamente, a sessão precisa permitir gravação."
         waitmoderator: "Participantes não podem entrar até que um moderador entre"
         allmoderators: "Todos usuários serão moderadores"
         create_moodle_calendar_event: "Cria um evento correspondente no Calendário do Moodle para esta sessão agendada."

--- a/db/migrate/20260821034401_add_auto_start_recording_to_consumer_configs.rb
+++ b/db/migrate/20260821034401_add_auto_start_recording_to_consumer_configs.rb
@@ -1,0 +1,5 @@
+class AddAutoStartRecordingToConsumerConfigs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :consumer_configs, :auto_start_recording, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260821143840_add_auto_start_recording_to_scheduled_meetings.rb
+++ b/db/migrate/20260821143840_add_auto_start_recording_to_scheduled_meetings.rb
@@ -1,0 +1,5 @@
+class AddAutoStartRecordingToScheduledMeetings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :scheduled_meetings, :auto_start_recording, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_10_201611) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_21_143840) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -74,6 +74,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_10_201611) do
     t.boolean "allow_student_scheduling", default: false, null: false
     t.boolean "allow_ai_artifacts", default: true, null: false
     t.boolean "hide_recordings_history", default: false, null: false
+    t.boolean "auto_start_recording", default: false, null: false
     t.index ["key"], name: "index_consumer_configs_on_key", unique: true
   end
 
@@ -169,6 +170,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_10_201611) do
     t.datetime "last_meeting_date"
     t.bigint "moodle_attendance_session_id"
     t.string "moodle_attendance_internal_meeting_id"
+    t.boolean "auto_start_recording", default: false, null: false
     t.index ["created_by_launch_nonce"], name: "index_scheduled_meetings_on_created_by_launch_nonce"
     t.index ["hash_id"], name: "index_scheduled_meetings_on_hash_id", unique: true
     t.index ["repeat"], name: "index_scheduled_meetings_on_repeat"

--- a/themes/elos/assets/javascripts/schedule-elos.js
+++ b/themes/elos/assets/javascripts/schedule-elos.js
@@ -73,6 +73,39 @@ $(document).on('turbolinks:load', function(){
       }
     }
 
+    const recordingCheckbox = $('input[name="scheduled_meeting[recording]"].form-check-input');
+    const autoStartCheckbox = $('input[name="scheduled_meeting[auto_start_recording]"].form-check-input');
+    if (recordingCheckbox.length && autoStartCheckbox.length) {
+      const canAutoStart = autoStartCheckbox[0].dataset.canAutoStart === 'true';
+      const autoStartHint = autoStartCheckbox.closest('.form-check').find('.icon-label-hint');
+
+      function refreshAutoStartHint(text) {
+        if (!autoStartHint.length || !autoStartHint[0]) return;
+        const hintEl = autoStartHint[0];
+        const tooltipInstance = bootstrap.Tooltip.getInstance(hintEl);
+        if (tooltipInstance) tooltipInstance.dispose();
+        autoStartHint.attr('title', text);
+        autoStartHint.removeAttr('data-bs-original-title');
+        if (tooltipInstance) new bootstrap.Tooltip(hintEl);
+      }
+
+      function syncAutoStartRecording() {
+        if (!canAutoStart) return;
+
+        if (recordingCheckbox.prop('checked')) {
+          autoStartCheckbox.prop('disabled', false);
+          refreshAutoStartHint(I18n.t('default.scheduled_meeting.tooltip.auto_start_recording'));
+        } else {
+          autoStartCheckbox.prop('checked', false);
+          autoStartCheckbox.prop('disabled', true);
+          refreshAutoStartHint(I18n.t('default.scheduled_meeting.tooltip.auto_start_recording_requires_recording'));
+        }
+      }
+
+      recordingCheckbox.on('change', syncAutoStartRecording);
+      syncAutoStartRecording();
+    }
+
     if(window.location.href.includes('/edit')){
       var duration = document.getElementsByName("scheduled_meeting[custom_duration]")[0].value,
           durationSeconds = (duration.split(':')[0] * 60 * 60 ) + ( duration.split(':')[1] * 60 ),

--- a/themes/elos/assets/stylesheets/theme-application-elos.scss
+++ b/themes/elos/assets/stylesheets/theme-application-elos.scss
@@ -877,6 +877,20 @@ body.theme-elos {
     }
   }
 
+  .badge-auto-start-recording {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background-color: var(--color-sec);
+    color: var(--color-white);
+    white-space: normal;
+    text-align: left;
+
+    .material-icons {
+      font-size: 1rem;
+    }
+  }
+
   .to-top {
     position: fixed;
     bottom: 5%;

--- a/themes/elos/config/locales/en.yml
+++ b/themes/elos/config/locales/en.yml
@@ -151,6 +151,7 @@ en:
       entering: "Acessing..."
       title: "Classes"
   scheduled_meetings:
+    auto_start_recording_notice: "The session will be recorded from the start"
     created_by: "Created by %{name}"
     destroy: "Remove"
     edit:

--- a/themes/elos/config/locales/en.yml
+++ b/themes/elos/config/locales/en.yml
@@ -55,6 +55,7 @@ en:
         start_time_time: "Start time"
         wait_moderator: "Wait for a moderator to join"
         welcome: "Welcome message (optional)"
+        auto_start_recording: "Automatically start recording"
   jobs:
     moodle_attendance:
       attendance_name: "Attendance Activity"

--- a/themes/elos/config/locales/es.yml
+++ b/themes/elos/config/locales/es.yml
@@ -55,6 +55,7 @@ es:
         start_time_time: "Hora de inicio"
         wait_moderator: "Espere a que ingrese el moderador para entrar"
         welcome: "Mensaje de bienvenida (opcional)"
+        auto_start_recording: "Iniciar grabación automáticamente"
   jobs:
     moodle_attendance:
       attendance_name: "Actividad de Asistencia"

--- a/themes/elos/config/locales/es.yml
+++ b/themes/elos/config/locales/es.yml
@@ -151,6 +151,7 @@ es:
       entering: "Accediendo..."
       title: "Clases"
   scheduled_meetings:
+    auto_start_recording_notice: "La sesión se grabará desde el inicio"
     created_by: "Creado por %{name}"
     destroy: "Eliminar"
     edit:

--- a/themes/elos/config/locales/pt.yml
+++ b/themes/elos/config/locales/pt.yml
@@ -55,6 +55,7 @@ pt:
         start_time_time: "Hora de início"
         wait_moderator: "Aguardar moderador para entrar"
         welcome: "Mensagem de boas vindas (opcional)"
+        auto_start_recording: "Iniciar gravação automaticamente"
   jobs:
     moodle_attendance:
       attendance_name: "Atividade de Presença"

--- a/themes/elos/config/locales/pt.yml
+++ b/themes/elos/config/locales/pt.yml
@@ -151,6 +151,7 @@ pt:
       entering: "Acessando..."
       title: "Turmas"
   scheduled_meetings:
+    auto_start_recording_notice: "A sessão será gravada desde o início"
     created_by: "Criado por %{name}"
     destroy: "Remover"
     edit:

--- a/themes/elos/views/scheduled_meetings/_form.html.erb
+++ b/themes/elos/views/scheduled_meetings/_form.html.erb
@@ -112,6 +112,25 @@
         </div>
       </div>
 
+      <% can_auto_start_recording = @room.auto_start_recording %>
+      <div class="form-group">
+        <div class="form-check">
+          <%= form.check_box :auto_start_recording,
+            class: "form-check-input",
+            checked: can_auto_start_recording && (@scheduled_meeting.persisted? ? @scheduled_meeting.auto_start_recording : true),
+            disabled: !can_auto_start_recording,
+            data: { 'tracking-id': 'lti-check-auto-start-recording', 'institution-guid': "#{@institution_guid}",
+                    'can-auto-start': can_auto_start_recording } %>
+          <%= form.label :auto_start_recording, class: "form-check-label" do %>
+            <%= t('helpers.label.scheduled_meeting.auto_start_recording') %>
+            <i class="icon material-icons icon-label-hint" data-bs-toggle="tooltip"
+              title="<%= can_auto_start_recording ?
+              t('default.scheduled_meeting.tooltip.auto_start_recording') :
+              t('default.scheduled_meeting.tooltip.auto_start_recording_disabled') %>">help</i>
+          <% end %>
+        </div>
+      </div>
+
       <%# show Brightspace OR Moodle attendance checkbox %>
       <% if @room.brightspace_oauth? %>
         <% can_mark_bright_attendance = @room.can_mark_brightspace_attendance? %>

--- a/themes/elos/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/elos/views/shared/_scheduled_meeting_row.html.erb
@@ -10,6 +10,12 @@
         <div class="item-creator"><%= t('scheduled_meetings.created_by', name: creator) %></div>
       <% end %>
     <% end %>
+    <% if meeting.will_auto_start_recording?(room) %>
+      <span class="badge badge-auto-start-recording mt-1">
+        <i class="icon material-icons">radio_button_checked</i>
+        <span><%= t('scheduled_meetings.auto_start_recording_notice') %></span>
+      </span>
+    <% end %>
   </td>
   <td class="col-12 col-md-3 align-middle">
     <%= format_date(meeting.start_at) %>

--- a/themes/rnp/assets/javascripts/schedule-rnp.js
+++ b/themes/rnp/assets/javascripts/schedule-rnp.js
@@ -73,6 +73,40 @@ $(document).on('turbolinks:load', function(){
       }
     }
 
+
+    const recordingCheckbox = $('input[name="scheduled_meeting[recording]"].form-check-input');
+    const autoStartCheckbox = $('input[name="scheduled_meeting[auto_start_recording]"].form-check-input');
+    if (recordingCheckbox.length && autoStartCheckbox.length) {
+      const canAutoStart = autoStartCheckbox[0].dataset.canAutoStart === 'true';
+      const autoStartHint = autoStartCheckbox.closest('.form-check').find('.icon-label-hint');
+
+      function refreshAutoStartHint(text) {
+        if (!autoStartHint.length || !autoStartHint[0]) return;
+        const hintEl = autoStartHint[0];
+        const tooltipInstance = bootstrap.Tooltip.getInstance(hintEl);
+        if (tooltipInstance) tooltipInstance.dispose();
+        autoStartHint.attr('title', text);
+        autoStartHint.removeAttr('data-bs-original-title');
+        if (tooltipInstance) new bootstrap.Tooltip(hintEl);
+      }
+
+      function syncAutoStartRecording() {
+        if (!canAutoStart) return; // consumer disabled it, ERB already handled the state
+
+        if (recordingCheckbox.prop('checked')) {
+          autoStartCheckbox.prop('disabled', false);
+          refreshAutoStartHint(I18n.t('default.scheduled_meeting.tooltip.auto_start_recording'));
+        } else {
+          autoStartCheckbox.prop('checked', false);
+          autoStartCheckbox.prop('disabled', true);
+          refreshAutoStartHint(I18n.t('default.scheduled_meeting.tooltip.auto_start_recording_requires_recording'));
+        }
+      }
+
+      recordingCheckbox.on('change', syncAutoStartRecording);
+      syncAutoStartRecording();
+    }
+
     if(window.location.href.includes('/edit')){
       var duration = document.getElementsByName("scheduled_meeting[custom_duration]")[0].value,
           durationSeconds = (duration.split(':')[0] * 60 * 60 ) + ( duration.split(':')[1] * 60 ),

--- a/themes/rnp/assets/stylesheets/theme-application-rnp.scss
+++ b/themes/rnp/assets/stylesheets/theme-application-rnp.scss
@@ -1143,6 +1143,20 @@ body.theme-rnp {
     }
   }
 
+  .badge-auto-start-recording {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background-color: #074AA0;
+    color: var(--color-white);
+    white-space: normal;
+    text-align: left;
+
+    .material-icons {
+      font-size: 1rem;
+    }
+  }
+
   .to-top {
     position: fixed;
     bottom: 5%;

--- a/themes/rnp/config/locales/en.yml
+++ b/themes/rnp/config/locales/en.yml
@@ -193,6 +193,7 @@ en:
       message: "Thank you for participating and until the next time."
       title: "Your session has ended"
   scheduled_meetings:
+    auto_start_recording_notice: "The session will be recorded from the start"
     created_by: "Created by %{name}"
     destroy: "Remove"
     edit:

--- a/themes/rnp/config/locales/en.yml
+++ b/themes/rnp/config/locales/en.yml
@@ -62,6 +62,7 @@ en:
         start_time_time: "Start time"
         wait_moderator: "Wait for a moderator to join"
         welcome: "Welcome message (optional)"
+        auto_start_recording: "Automatically start recording"
   jobs:
     moodle_attendance:
       attendance_name: "Attendance Activity"

--- a/themes/rnp/config/locales/es.yml
+++ b/themes/rnp/config/locales/es.yml
@@ -62,6 +62,7 @@ es:
         start_time_time: "Hora de inicio"
         wait_moderator: "Espere a que ingrese el moderador para entrar"
         welcome: "Mensaje de bienvenida (opcional)"
+        auto_start_recording: "Iniciar grabación automáticamente"
   jobs:
     moodle_attendance:
       attendance_name: "Actividad de Asistencia"

--- a/themes/rnp/config/locales/es.yml
+++ b/themes/rnp/config/locales/es.yml
@@ -193,6 +193,7 @@ es:
       message: "Gracias por su participación y hasta luego."
       title: "Tu sesión ha terminado"
   scheduled_meetings:
+    auto_start_recording_notice: "La sesión se grabará desde el inicio"
     created_by: "Creado por %{name}"
     destroy: "Eliminar"
     edit:

--- a/themes/rnp/config/locales/pt.yml
+++ b/themes/rnp/config/locales/pt.yml
@@ -62,6 +62,7 @@ pt:
         start_time_time: "Hora de início"
         wait_moderator: "Aguardar moderador para entrar"
         welcome: "Mensagem de boas vindas (opcional)"
+        auto_start_recording: "Iniciar gravação automaticamente"
   jobs:
     moodle_attendance:
       attendance_name: "Atividade de Presença"

--- a/themes/rnp/config/locales/pt.yml
+++ b/themes/rnp/config/locales/pt.yml
@@ -193,6 +193,7 @@ pt:
       message: "Obrigado pela sua participação e até a próxima."
       title: "Sua sessão acabou"
   scheduled_meetings:
+    auto_start_recording_notice: "A sessão será gravada desde o início"
     created_by: "Criado por %{name}"
     destroy: "Remover"
     edit:

--- a/themes/rnp/views/scheduled_meetings/_form.html.erb
+++ b/themes/rnp/views/scheduled_meetings/_form.html.erb
@@ -112,6 +112,24 @@
         </div>
       </div>
 
+      <% can_auto_start_recording = @room.auto_start_recording %>
+      <div class="form-group">
+        <div class="form-check">
+          <%= form.check_box :auto_start_recording,
+              class: "form-check-input",
+              checked: can_auto_start_recording && (@scheduled_meeting.persisted? ? @scheduled_meeting.auto_start_recording : true),
+              disabled: !can_auto_start_recording,
+              data: { 'tracking-id': 'lti-check-auto-start-recording', 'institution-guid': "#{@institution_guid}",
+                      'can-auto-start': can_auto_start_recording } %>
+          <%= form.label :auto_start_recording, class: "form-check-label" do %>
+            <%= t('helpers.label.scheduled_meeting.auto_start_recording') %>
+            <i class="icon material-icons icon-label-hint" data-bs-toggle="tooltip"
+              title="<%= can_auto_start_recording ?
+              t('default.scheduled_meeting.tooltip.auto_start_recording') :
+              t('default.scheduled_meeting.tooltip.auto_start_recording_disabled') %>">help</i>
+          <% end %>
+        </div>
+      </div>
 
       <% can_mark_attendance = @room.can_mark_moodle_attendance %>
       <div class="form-group">

--- a/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
+++ b/themes/rnp/views/shared/_scheduled_meeting_row.html.erb
@@ -10,6 +10,12 @@
         <div class="item-creator"><%= t('scheduled_meetings.created_by', name: creator) %></div>
       <% end %>
     <% end %>
+    <% if meeting.will_auto_start_recording?(room) %>
+      <span class="badge badge-auto-start-recording mt-1">
+        <i class="icon material-icons">radio_button_checked</i>
+        <span><%= t('scheduled_meetings.auto_start_recording_notice') %></span>
+      </span>
+    <% end %>
   </td>
   <td class="col-12 col-md-3 align-middle">
     <%= format_date(meeting.start_at) %>


### PR DESCRIPTION
This PR lets an institution configure its rooms so sessions start with recording already on, and warning students on the scheduled meetings list. Changes apllied to both Elos and RNP Themes

The `auto_start_recording` flag lives in two layers: on `ConsumerConfig` (sent by the broker on launch, per institution) and on `ScheduledMeeting` (the creator choice per session). 

The institutional flag acts as a ceiling, not as an initial value: `create_options` only sends `autoStartRecording=true` to BBB when the session allows recording **and** the teacher checked it **and** the consumer still has the flag on. If the institution turns it off later, old meetings stop auto recording with no data migration needed. The `recording` condition is part of the chain because without it the contradictory combination `record=false` + `autoStartRecording=true` could be saved.

On the form, the checkbox starts checked when the institution enables it, and the strong param is only permitted in that case, so a disabled checkbox won't accept a forged parameter. A small script keeps it in sync with the "allow recording" checkbox without a reload.

**Visual Changes**

Elos:
<img width="750" height="459" alt="aviso_lista_schedules_17-10_bbb-app-rooms_24-08" src="https://github.com/user-attachments/assets/1cddfff3-965a-4664-85ad-3f4397dad3b6" />
RNP:
<img width="750" height="459" alt="aviso_rnp_17-19_bbb-app-rooms_24-08" src="https://github.com/user-attachments/assets/b6df6488-4634-4cc6-9101-f78be0cd7155" />

New checkbox:
<img width="750" height="459" alt="checkbox_habilitada_14-57_bbb-app-rooms_21-08" src="https://github.com/user-attachments/assets/8e6b0363-595c-4925-a7e9-e4f38a8975cc" />
